### PR TITLE
Update YAML example to show permissions needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ Sample `.github/workflows/main.yml`:
 
 ```YAML
 on: [status]
+
+permissions: read-all
+
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
     if: "${{ github.event.context == 'ci/circleci: build_doc' }}"
+    permissions:
+      statuses: write
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
I've seen this issue #33 which have helped me a lot on setting the write permissions to circleci-artifacts-redirector-action at https://github.com/numpy/numpy/pull/23294 .

This permission configuration worked fine and it is possible that a even more specific permissions would also work (`contents: read` instead of `read-all`, for example), but considering I've not tested this scenarios, I would stick to what works.

Let me know if you have any doubts or concerns about this.