### PR TITLE
WIP: Require API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/test_artifacts/root_artifact.md
           circleci-jobs: build_doc
           job-title: Check the rendered docs here!
@@ -37,6 +38,13 @@ jobs:
   conditional in the `job` is helpful to limit the number of redirector
   actions that your repo will run to avoid polluting your GitHub actions
   logs. The `circleci-jobs` (below) should be labeled correspondingly.
+- The `api-token` needs to be a token whose public key has been added
+  to the GitHub secrets of your repository and the private key added as a
+  CircleCI project API token with admin permissions, e.g. for the
+  MNE-Python project this would be:
+
+  - https://github.com/mne-tools/mne-python/settings/secrets/actions
+  - https://app.circleci.com/settings/project/github/mne-tools/mne-python/api
 - The `artifact-path` should point to an artifact path from your CircleCI
   build. This is typically whatever follows the CircleCI artifact root path,
   for example `0/test_artifacts/root_artifact.md`.


### PR DESCRIPTION
I tried this approach but it seems to have not worked here, despite having the token:

https://github.com/mne-tools/mne-python/actions/runs/4670442712/jobs/8270174430

```
##[debug]17:44:26 GMT+0000 (Coordinated Universal Time)
##[debug]Considering CircleCI jobs named: ci/circleci: build_docs,ci/circleci: build_docs_main
##[debug]context:    ci/circleci: build_docs
##[debug]state:      pending
##[debug]target_url: https://circleci.com/gh/mne-tools/mne-python/538[34](https://github.com/mne-tools/mne-python/actions/runs/4670442712/jobs/8270174430#step:2:35)
##[debug]org:   mne-tools
##[debug]repo:  mne-python
##[debug]build: 5[38](https://github.com/mne-tools/mne-python/actions/runs/4670442712/jobs/8270174430#step:2:39)34
##[debug]Fetching JSON: https://circleci.com/api/v2/project/gh/mne-tools/mne-python/53834/artifacts
##[debug]Successfully read CircleCI API token ***
##[debug]Artifacts JSON (status=[40](https://github.com/mne-tools/mne-python/actions/runs/4670442712/jobs/8270174430#step:2:41)4):
##[debug]{"message":"Job not found."}
```