### PR TITLE
STY: Enforce code style with ESLint rules

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44024,8 +44024,8 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     const payload = context.payload
     const path = getInput('artifact-path', {required: true})
     const token = getInput('repo-token', {required: true})
-    var apiToken = getInput('api-token', {required: false})
-    var circleciJobs = getInput('circleci-jobs', {required: false})
+    let apiToken = getInput('api-token', {required: false})
+    let circleciJobs = getInput('circleci-jobs', {required: false})
     if (circleciJobs === '') {
       circleciJobs = 'build_docs,doc,build'
     }
@@ -44052,73 +44052,73 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     // e.g., https://circleci.com/gh/mne-tools/mne-python/53315
     // e.g., https://circleci.com/gh/scientific-python/circleci-artifacts-redirector-action/94?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
     // Set the new status
-    let artifacts_url = '';
-    const target = payload.target_url.split('?')[0];   // strip any ?utm=…
+    let artifacts_url = ''
+    const target = payload.target_url.split('?')[0]   // strip any ?utm=…
     if (target.includes('/pipelines/circleci/') || target.includes('app.circleci.com/workflow/')) {
       // ───── New GitHub‑App URL ───────────────────────────────────────────
       // .../pipelines/circleci/<org‑id>/<project‑id>/<pipe‑seq>/workflows/<workflow‑id>
       // OR
       // .../workflow/<workflow-id>
-      const workflowId = target.split('/').pop();
-      core_debug(`workflow: ${workflowId}`);
+      const workflowId = target.split('/').pop()
+      core_debug(`workflow: ${workflowId}`)
 
       // 1. Get the jobs that belong to this workflow
       const jobsRes = await fetchFn(
         `https://circleci.com/api/v2/workflow/${workflowId}/job`
-      );
-      const jobs = await jobsRes.json();
+      )
+      const jobs = await jobsRes.json()
       if (!jobs.items.length) {
-        setFailed(`No jobs returned for workflow ${workflowId}`);
-        return;
+        setFailed(`No jobs returned for workflow ${workflowId}`)
+        return
       }
 
       // 2. Identify and select the relevant job
       // The simplest case is when a workflow contains only a single job, just
       //  select the first entry
-      let job = null;
+      let job = null
       if (jobs.items.length === 1) {
-        job = jobs.items[0];
-        core_debug("Workflow contains one job.");
+        job = jobs.items[0]
+        core_debug('Workflow contains one job.')
       }
       // If there are multiple jobs in the workflow, select the first one that
       //  matches one of the job names passed to the action.
       else {
         for (const jobItem of jobs.items) {
-          core_debug(`Checking job: ${jobItem.name} against ${circleciJobNames.join(',')}`);
+          core_debug(`Checking job: ${jobItem.name} against ${circleciJobNames.join(',')}`)
           if (circleciJobNames.includes(jobItem.name)) {
-            job = jobItem;
-            break;
+            job = jobItem
+            break
           }
         }
 
         // In the case where no matching job is found, use the first job
         if (job == null) {
-          job = jobs.items[0];
-          core_debug(`No matching job found for ${circleciJobNames.join(', ')}. Using first job: ${job.name}`);
+          job = jobs.items[0]
+          core_debug(`No matching job found for ${circleciJobNames.join(', ')}. Using first job: ${job.name}`)
         }
       }
 
       // Extract the project slug and job number from the selected job
-      const projectSlug = job.project_slug;  // "circleci/<org‑id>/<project‑id>"
-      const jobNumber   = job.job_number;
+      const projectSlug = job.project_slug  // "circleci/<org‑id>/<project‑id>"
+      const jobNumber   = job.job_number
 
-      core_debug(`slug:  ${projectSlug}`);
-      core_debug(`job#:  ${jobNumber}`);
+      core_debug(`slug:  ${projectSlug}`)
+      core_debug(`job#:  ${jobNumber}`)
 
       // 3. Construct the v2 artifacts endpoint
-      artifacts_url = `https://circleci.com/api/v2/project/${projectSlug}/${jobNumber}/artifacts`;
+      artifacts_url = `https://circleci.com/api/v2/project/${projectSlug}/${jobNumber}/artifacts`
     } else {
       // ───── Legacy OAuth URL (…/gh/<org>/<repo>/<build>) ────────────────
-      const parts    = target.split('/');
-      const orgId    = parts.slice(-3)[0];
-      const repoId   = parts.slice(-2)[0];
-      const buildId  = parts.slice(-1)[0];
+      const parts    = target.split('/')
+      const orgId    = parts.slice(-3)[0]
+      const repoId   = parts.slice(-2)[0]
+      const buildId  = parts.slice(-1)[0]
 
       artifacts_url =
-        `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`;
+        `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`
     }
     core_debug(`Fetching JSON: ${artifacts_url}`)
-    if (apiToken == null || apiToken == '') {
+    if (apiToken == null || apiToken === '') {
       apiToken = 'null'
     }
     else {
@@ -44131,27 +44131,27 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     core_debug(`Artifacts JSON (status=${response.status}):`)
     core_debug(JSON.stringify(artifacts))
     // e.g., {"next_page_token":null,"items":[{"path":"test_artifacts/root_artifact.md","node_index":0,"url":"https://output.circle-artifacts.com/output/job/6fdfd148-31da-4a30-8e89-a20595696ca5/artifacts/0/test_artifacts/root_artifact.md"}]}
-    var url = '';
+    let url = ''
     const hasArtifacts = artifacts.items.length > 0
     if (hasArtifacts) {
       url = `${artifacts.items[0].url.split('/artifacts/')[0]}/artifacts/${path}`
       // Set root domain
-      var domain = getInput('domain')
+      const domain = getInput('domain')
       url = `https://${domain}/output/${url.split('/output/')[1]}`
     }
     else {
       // Nothing was uploaded, so the best we can do is link to the job itself.
       // (Rewriting the domain only makes sense for artifact URLs.)
-      url = payload.target_url;
+      url = payload.target_url
     }
     core_debug(`Linking to: ${url}`)
     core_debug((new Date()).toTimeString())
-    setOutput("url", url)
+    setOutput('url', url)
     const client = getOctokit(token)
     // The status reports whether the link is usable, not whether the CircleCI
     // job passed (gh-57): a job can fail late and still upload good artifacts,
     // and the job's own status already reports the failure.
-    var description = '';
+    let description = ''
     if (payload.state === 'pending') {
       description = 'Waiting for CircleCI ...'
     }
@@ -44163,7 +44163,7 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
       state = 'failure'
       description = 'No artifacts found'
     }
-    var job_title = getInput('job-title', {required: false})
+    let job_title = getInput('job-title', {required: false})
     if (job_title === '') {
       job_title = `${payload.context} artifact`
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,29 +1,37 @@
-import { defineConfig } from "eslint/config";
-import globals from "globals";
-import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
+import { defineConfig } from 'eslint/config'
+import globals from 'globals'
+import js from '@eslint/js'
+import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
     recommendedConfig: js.configs.recommended,
     allConfig: js.configs.all
-});
+})
 
 export default defineConfig([{
-    ignores: ["dist/**"],
+    ignores: ['dist/**'],
 }, {
-    extends: compat.extends("eslint:recommended"),
+    extends: compat.extends('eslint:recommended'),
 
     languageOptions: {
         globals: {
             ...globals.commonjs,
             ...globals.node,
-            Atomics: "readonly",
-            SharedArrayBuffer: "readonly",
+            Atomics: 'readonly',
+            SharedArrayBuffer: 'readonly',
         },
 
         ecmaVersion: 2022,
-        sourceType: "module",
+        sourceType: 'module',
     },
 
-    rules: {},
-}]);
+    // The codebase was written without semicolons, so enforce that rather than
+    // churn every line. All of these are autofixable with `npx eslint . --fix`.
+    rules: {
+        eqeqeq: ['error', 'always', {null: 'ignore'}],
+        'no-var': 'error',
+        'prefer-const': 'error',
+        quotes: ['error', 'single', {avoidEscape: true}],
+        semi: ['error', 'never'],
+    },
+}])

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     const payload = context.payload
     const path = core.getInput('artifact-path', {required: true})
     const token = core.getInput('repo-token', {required: true})
-    var apiToken = core.getInput('api-token', {required: false})
-    var circleciJobs = core.getInput('circleci-jobs', {required: false})
+    let apiToken = core.getInput('api-token', {required: false})
+    let circleciJobs = core.getInput('circleci-jobs', {required: false})
     if (circleciJobs === '') {
       circleciJobs = 'build_docs,doc,build'
     }
@@ -48,73 +48,73 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     // e.g., https://circleci.com/gh/mne-tools/mne-python/53315
     // e.g., https://circleci.com/gh/scientific-python/circleci-artifacts-redirector-action/94?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
     // Set the new status
-    let artifacts_url = '';
-    const target = payload.target_url.split('?')[0];   // strip any ?utm=…
+    let artifacts_url = ''
+    const target = payload.target_url.split('?')[0]   // strip any ?utm=…
     if (target.includes('/pipelines/circleci/') || target.includes('app.circleci.com/workflow/')) {
       // ───── New GitHub‑App URL ───────────────────────────────────────────
       // .../pipelines/circleci/<org‑id>/<project‑id>/<pipe‑seq>/workflows/<workflow‑id>
       // OR
       // .../workflow/<workflow-id>
-      const workflowId = target.split('/').pop();
-      core.debug(`workflow: ${workflowId}`);
+      const workflowId = target.split('/').pop()
+      core.debug(`workflow: ${workflowId}`)
 
       // 1. Get the jobs that belong to this workflow
       const jobsRes = await fetchFn(
         `https://circleci.com/api/v2/workflow/${workflowId}/job`
-      );
-      const jobs = await jobsRes.json();
+      )
+      const jobs = await jobsRes.json()
       if (!jobs.items.length) {
-        core.setFailed(`No jobs returned for workflow ${workflowId}`);
-        return;
+        core.setFailed(`No jobs returned for workflow ${workflowId}`)
+        return
       }
 
       // 2. Identify and select the relevant job
       // The simplest case is when a workflow contains only a single job, just
       //  select the first entry
-      let job = null;
+      let job = null
       if (jobs.items.length === 1) {
-        job = jobs.items[0];
-        core.debug("Workflow contains one job.");
+        job = jobs.items[0]
+        core.debug('Workflow contains one job.')
       }
       // If there are multiple jobs in the workflow, select the first one that
       //  matches one of the job names passed to the action.
       else {
         for (const jobItem of jobs.items) {
-          core.debug(`Checking job: ${jobItem.name} against ${circleciJobNames.join(',')}`);
+          core.debug(`Checking job: ${jobItem.name} against ${circleciJobNames.join(',')}`)
           if (circleciJobNames.includes(jobItem.name)) {
-            job = jobItem;
-            break;
+            job = jobItem
+            break
           }
         }
 
         // In the case where no matching job is found, use the first job
         if (job == null) {
-          job = jobs.items[0];
-          core.debug(`No matching job found for ${circleciJobNames.join(', ')}. Using first job: ${job.name}`);
+          job = jobs.items[0]
+          core.debug(`No matching job found for ${circleciJobNames.join(', ')}. Using first job: ${job.name}`)
         }
       }
 
       // Extract the project slug and job number from the selected job
-      const projectSlug = job.project_slug;  // "circleci/<org‑id>/<project‑id>"
-      const jobNumber   = job.job_number;
+      const projectSlug = job.project_slug  // "circleci/<org‑id>/<project‑id>"
+      const jobNumber   = job.job_number
 
-      core.debug(`slug:  ${projectSlug}`);
-      core.debug(`job#:  ${jobNumber}`);
+      core.debug(`slug:  ${projectSlug}`)
+      core.debug(`job#:  ${jobNumber}`)
 
       // 3. Construct the v2 artifacts endpoint
-      artifacts_url = `https://circleci.com/api/v2/project/${projectSlug}/${jobNumber}/artifacts`;
+      artifacts_url = `https://circleci.com/api/v2/project/${projectSlug}/${jobNumber}/artifacts`
     } else {
       // ───── Legacy OAuth URL (…/gh/<org>/<repo>/<build>) ────────────────
-      const parts    = target.split('/');
-      const orgId    = parts.slice(-3)[0];
-      const repoId   = parts.slice(-2)[0];
-      const buildId  = parts.slice(-1)[0];
+      const parts    = target.split('/')
+      const orgId    = parts.slice(-3)[0]
+      const repoId   = parts.slice(-2)[0]
+      const buildId  = parts.slice(-1)[0]
 
       artifacts_url =
-        `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`;
+        `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`
     }
     core.debug(`Fetching JSON: ${artifacts_url}`)
-    if (apiToken == null || apiToken == '') {
+    if (apiToken == null || apiToken === '') {
       apiToken = 'null'
     }
     else {
@@ -127,27 +127,27 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     core.debug(`Artifacts JSON (status=${response.status}):`)
     core.debug(JSON.stringify(artifacts))
     // e.g., {"next_page_token":null,"items":[{"path":"test_artifacts/root_artifact.md","node_index":0,"url":"https://output.circle-artifacts.com/output/job/6fdfd148-31da-4a30-8e89-a20595696ca5/artifacts/0/test_artifacts/root_artifact.md"}]}
-    var url = '';
+    let url = ''
     const hasArtifacts = artifacts.items.length > 0
     if (hasArtifacts) {
       url = `${artifacts.items[0].url.split('/artifacts/')[0]}/artifacts/${path}`
       // Set root domain
-      var domain = core.getInput('domain')
+      const domain = core.getInput('domain')
       url = `https://${domain}/output/${url.split('/output/')[1]}`
     }
     else {
       // Nothing was uploaded, so the best we can do is link to the job itself.
       // (Rewriting the domain only makes sense for artifact URLs.)
-      url = payload.target_url;
+      url = payload.target_url
     }
     core.debug(`Linking to: ${url}`)
     core.debug((new Date()).toTimeString())
-    core.setOutput("url", url)
+    core.setOutput('url', url)
     const client = getOctokit(token)
     // The status reports whether the link is usable, not whether the CircleCI
     // job passed (gh-57): a job can fail late and still upload good artifacts,
     // and the job's own status already reports the failure.
-    var description = '';
+    let description = ''
     if (payload.state === 'pending') {
       description = 'Waiting for CircleCI ...'
     }
@@ -159,7 +159,7 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
       state = 'failure'
       description = 'No artifacts found'
     }
-    var job_title = core.getInput('job-title', {required: false})
+    let job_title = core.getInput('job-title', {required: false})
     if (job_title === '') {
       job_title = `${payload.context} artifact`
     }


### PR DESCRIPTION
Tier 3 item 9 from the modernization list: encode the existing style as lint rules rather than convention.

Adds `semi: never`, `no-var`, `prefer-const`, `quotes: single`, and `eqeqeq` (with `{null: 'ignore'}`), then applies `npx eslint . --fix`. The rules match the dominant existing style — the file was 53 lines without semicolons vs 28 with, and single quotes 79 to 22 — so this minimizes churn rather than imposing a new style.

Every change is mechanical except one: `apiToken == ''` -> `apiToken === ''`, which ESLint can't autofix. The `== null` checks are intentional (they match `undefined` too) and are preserved via `{null: 'ignore'}`.

Tests unchanged: 12 passing, 100% line/branch/function coverage.

This one is pure blame noise, so a follow-up PR will add `.git-blame-ignore-revs` pointing at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)