### PR TITLE
MAINT: Modernize code structure and CI hygiene

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Revisions listed here are ignored by `git blame` (and by GitHub's blame view).
+# Add style-only commits, never ones that change behavior.
+#
+# Run this once locally to make git use it by default:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# STY: Enforce code style with ESLint rules (#115)
+f867cf6c6db0ad1d9cfe111d27795b8d13d72d6b

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,13 +10,17 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Rebuild dist
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '24.x'
       - run: npm install

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -4,6 +4,7 @@ jobs:
     permissions:
       statuses: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: "${{ github.event.context == 'ci/circleci: build' }}"
     name: CircleCI artifacts redirector status
     outputs:
@@ -20,7 +21,7 @@ jobs:
       - name: Print expected ref
         run: echo SHA=${{ github.event.sha }}
       - name: Checkout repo
-        uses: actions/checkout@master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ github.event.sha }}
       - name: Check history
@@ -35,13 +36,15 @@ jobs:
         id: run-circleci-artifacts-redirector
 
   use_outputs_status_job:
+    permissions: {}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [circleci_artifacts_redirector_status_job]
     name: Use the status output
     if: github.event.state != 'pending'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ github.event.sha }}
       - name: Get expected commit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '24.x'
       - run: which node && node --version && which npm && npm --version
       - run: npm install
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
       - run: npm run coverage
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ These changes will automatically be compiled into `dist/index.js` by the
 If you want to do the same work locally as the bot, use `npm install` to get
 all dependencies and then call `ncc build index.js -o dist`.
 
+Style-only commits are listed in `.git-blame-ignore-revs`; run
+`git config blame.ignoreRevsFile .git-blame-ignore-revs` once locally to have
+`git blame` skip them (GitHub's blame view uses the file automatically).
+
 Unit tests live in `index.test.js` and use the
 [Node.js test runner](https://nodejs.org/api/test.html). Run them with
 `npm test` (which also lints), or `npm run coverage` to additionally write an

--- a/dist/index.js
+++ b/dist/index.js
@@ -34592,7 +34592,11 @@ var __webpack_exports__ = {};
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
-  e: () => (/* binding */ run)
+  O$: () => (/* binding */ legacyArtifactsUrl),
+  BH: () => (/* binding */ pickJob),
+  Qc: () => (/* binding */ redirectUrl),
+  eF: () => (/* binding */ run),
+  SR: () => (/* binding */ statusFor)
 });
 
 ;// CONCATENATED MODULE: external "os"
@@ -44016,6 +44020,48 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 
 
 
+// Pick the job whose artifacts should be linked. A single-job workflow is
+// unambiguous; otherwise prefer a job the user asked for, and fall back to the
+// first one.
+function pickJob(items, jobNames) {
+  if (items.length === 1) {
+    return items[0]
+  }
+  return items.find((job) => jobNames.includes(job.name)) ?? items[0]
+}
+
+// Turn a legacy OAuth target_url (…/gh/<org>/<repo>/<build>) into the v2
+// artifacts endpoint.
+function legacyArtifactsUrl(target) {
+  const [orgId, repoId, buildId] = new URL(target).pathname.split('/').slice(-3)
+  return `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`
+}
+
+// Build the URL to link to: the requested artifact if anything was uploaded,
+// otherwise the CircleCI job itself (rewriting the domain only makes sense for
+// artifact URLs).
+function redirectUrl(items, path, domain, fallback) {
+  if (!items.length) {
+    return fallback
+  }
+  // e.g., https://output.circle-artifacts.com/output/job/<uuid>/artifacts/0/doc/index.html
+  const job = items[0].url.split('/output/')[1].split('/artifacts/')[0]
+  return `https://${domain}/output/${job}/artifacts/${path}`
+}
+
+// The status reports whether the link is usable, not whether the CircleCI job
+// passed (gh-57): a job can fail late and still upload good artifacts, and the
+// job's own status already reports the failure.
+function statusFor(payloadState, hasArtifacts, path) {
+  if (payloadState === 'pending') {
+    return {state: payloadState, description: 'Waiting for CircleCI ...'}
+  }
+  if (hasArtifacts) {
+    return {state: 'success', description: `Link to ${path}`}
+  }
+  return {state: 'failure', description: 'No artifacts found'}
+}
+
 // The context/fetch/octokit arguments exist so that tests can inject fakes;
 // in production the defaults are always used.
 async function run({context = github_context, fetchFn = fetch, getOctokit = github_getOctokit} = {}) {
@@ -44024,160 +44070,81 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     const payload = context.payload
     const path = getInput('artifact-path', {required: true})
     const token = getInput('repo-token', {required: true})
-    let apiToken = getInput('api-token', {required: false})
-    let circleciJobs = getInput('circleci-jobs', {required: false})
-    if (circleciJobs === '') {
-      circleciJobs = 'build_docs,doc,build'
-    }
+    const apiToken = getInput('api-token', {required: false})
+    const jobNames = (getInput('circleci-jobs', {required: false}) || 'build_docs,doc,build').split(',')
 
-    // Split circleJobs into an array of job names
-    const circleciJobNames = circleciJobs.split(',')
-
-    //  Defines a variable to help prefix each job name with ci/circleci
-    const prepender = x => `ci/circleci: ${x}`
-    circleciJobs = circleciJobNames.map(prepender)
-    core_debug(`Considering CircleCI jobs named: ${circleciJobs}`)
-
-    if (circleciJobs.indexOf(payload.context) < 0) {
+    // Each job reports itself as a "ci/circleci: <name>" status context
+    const contexts = jobNames.map((name) => `ci/circleci: ${name}`)
+    core_debug(`Considering CircleCI jobs named: ${contexts}`)
+    if (!contexts.includes(payload.context)) {
       core_debug(`Ignoring context: ${payload.context}`)
       return
     }
 
-    // Read out 'state' (whether CircleCI process was successful or not), then
-    //  store in debug output along with the target_url
-    let state = payload.state
     core_debug(`context:    ${payload.context}`)
-    core_debug(`state:      ${state}`)
+    core_debug(`state:      ${payload.state}`)
     core_debug(`target_url: ${payload.target_url}`)
     // e.g., https://circleci.com/gh/mne-tools/mne-python/53315
     // e.g., https://circleci.com/gh/scientific-python/circleci-artifacts-redirector-action/94?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
-    // Set the new status
-    let artifacts_url = ''
     const target = payload.target_url.split('?')[0]   // strip any ?utm=…
+    let artifactsUrl = ''
     if (target.includes('/pipelines/circleci/') || target.includes('app.circleci.com/workflow/')) {
       // ───── New GitHub‑App URL ───────────────────────────────────────────
       // .../pipelines/circleci/<org‑id>/<project‑id>/<pipe‑seq>/workflows/<workflow‑id>
       // OR
       // .../workflow/<workflow-id>
-      const workflowId = target.split('/').pop()
+      const workflowId = target.split('/').at(-1)
       core_debug(`workflow: ${workflowId}`)
 
-      // 1. Get the jobs that belong to this workflow
-      const jobsRes = await fetchFn(
-        `https://circleci.com/api/v2/workflow/${workflowId}/job`
-      )
+      const jobsRes = await fetchFn(`https://circleci.com/api/v2/workflow/${workflowId}/job`)
       const jobs = await jobsRes.json()
       if (!jobs.items.length) {
         setFailed(`No jobs returned for workflow ${workflowId}`)
         return
       }
 
-      // 2. Identify and select the relevant job
-      // The simplest case is when a workflow contains only a single job, just
-      //  select the first entry
-      let job = null
-      if (jobs.items.length === 1) {
-        job = jobs.items[0]
-        core_debug('Workflow contains one job.')
-      }
-      // If there are multiple jobs in the workflow, select the first one that
-      //  matches one of the job names passed to the action.
-      else {
-        for (const jobItem of jobs.items) {
-          core_debug(`Checking job: ${jobItem.name} against ${circleciJobNames.join(',')}`)
-          if (circleciJobNames.includes(jobItem.name)) {
-            job = jobItem
-            break
-          }
-        }
-
-        // In the case where no matching job is found, use the first job
-        if (job == null) {
-          job = jobs.items[0]
-          core_debug(`No matching job found for ${circleciJobNames.join(', ')}. Using first job: ${job.name}`)
-        }
-      }
-
-      // Extract the project slug and job number from the selected job
-      const projectSlug = job.project_slug  // "circleci/<org‑id>/<project‑id>"
-      const jobNumber   = job.job_number
-
-      core_debug(`slug:  ${projectSlug}`)
-      core_debug(`job#:  ${jobNumber}`)
-
-      // 3. Construct the v2 artifacts endpoint
-      artifacts_url = `https://circleci.com/api/v2/project/${projectSlug}/${jobNumber}/artifacts`
+      const job = pickJob(jobs.items, jobNames)
+      core_debug(`Using job ${job.name} of ${jobs.items.map((item) => item.name).join(', ')}`)
+      core_debug(`slug:  ${job.project_slug}`)  // "circleci/<org‑id>/<project‑id>"
+      core_debug(`job#:  ${job.job_number}`)
+      artifactsUrl = `https://circleci.com/api/v2/project/${job.project_slug}/${job.job_number}/artifacts`
     } else {
-      // ───── Legacy OAuth URL (…/gh/<org>/<repo>/<build>) ────────────────
-      const parts    = target.split('/')
-      const orgId    = parts.slice(-3)[0]
-      const repoId   = parts.slice(-2)[0]
-      const buildId  = parts.slice(-1)[0]
+      artifactsUrl = legacyArtifactsUrl(target)
+    }
 
-      artifacts_url =
-        `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`
-    }
-    core_debug(`Fetching JSON: ${artifacts_url}`)
-    if (apiToken == null || apiToken === '') {
-      apiToken = 'null'
-    }
-    else {
+    core_debug(`Fetching JSON: ${artifactsUrl}`)
+    if (apiToken !== '') {
       core_debug(`Successfully read CircleCI API token ${apiToken}`)
     }
-    const headers = {'Circle-Token': apiToken, 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
+    // CircleCI wants a literal "null" token for public projects
+    const headers = {'Circle-Token': apiToken || 'null', 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
     // e.g., https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts
-    const response = await fetchFn(artifacts_url, {headers})
+    const response = await fetchFn(artifactsUrl, {headers})
     const artifacts = await response.json()
     core_debug(`Artifacts JSON (status=${response.status}):`)
     core_debug(JSON.stringify(artifacts))
     // e.g., {"next_page_token":null,"items":[{"path":"test_artifacts/root_artifact.md","node_index":0,"url":"https://output.circle-artifacts.com/output/job/6fdfd148-31da-4a30-8e89-a20595696ca5/artifacts/0/test_artifacts/root_artifact.md"}]}
-    let url = ''
-    const hasArtifacts = artifacts.items.length > 0
-    if (hasArtifacts) {
-      url = `${artifacts.items[0].url.split('/artifacts/')[0]}/artifacts/${path}`
-      // Set root domain
-      const domain = getInput('domain')
-      url = `https://${domain}/output/${url.split('/output/')[1]}`
-    }
-    else {
-      // Nothing was uploaded, so the best we can do is link to the job itself.
-      // (Rewriting the domain only makes sense for artifact URLs.)
-      url = payload.target_url
-    }
+    const url = redirectUrl(artifacts.items, path, getInput('domain'), payload.target_url)
     core_debug(`Linking to: ${url}`)
     core_debug((new Date()).toTimeString())
     setOutput('url', url)
+
+    const {state, description} = statusFor(payload.state, artifacts.items.length > 0, path)
+    const jobTitle = getInput('job-title', {required: false}) || `${payload.context} artifact`
     const client = getOctokit(token)
-    // The status reports whether the link is usable, not whether the CircleCI
-    // job passed (gh-57): a job can fail late and still upload good artifacts,
-    // and the job's own status already reports the failure.
-    let description = ''
-    if (payload.state === 'pending') {
-      description = 'Waiting for CircleCI ...'
-    }
-    else if (hasArtifacts) {
-      state = 'success'
-      description = `Link to ${path}`
-    }
-    else {
-      state = 'failure'
-      description = 'No artifacts found'
-    }
-    let job_title = getInput('job-title', {required: false})
-    if (job_title === '') {
-      job_title = `${payload.context} artifact`
-    }
     return client.rest.repos.createCommitStatus({
       repo: context.repo.repo,
       owner: context.repo.owner,
       sha: payload.sha,
-      state: state,
+      state,
       target_url: url,
-      description: description,
-      context: job_title
+      description,
+      context: jobTitle
     })
   } catch (error) {
-    setFailed(error.message)
+    // Keep the failure itself readable; the stack is there with debug logging
+    core_debug(error.stack ?? String(error))
+    setFailed(error.message ?? String(error))
   }
 }
 
@@ -44188,5 +44155,9 @@ if (import.meta.url === (0,external_node_url_.pathToFileURL)(process.argv[1]).hr
   run()
 }
 
-var __webpack_exports__run = __webpack_exports__.e;
-export { __webpack_exports__run as run };
+var __webpack_exports__legacyArtifactsUrl = __webpack_exports__.O$;
+var __webpack_exports__pickJob = __webpack_exports__.BH;
+var __webpack_exports__redirectUrl = __webpack_exports__.Qc;
+var __webpack_exports__run = __webpack_exports__.eF;
+var __webpack_exports__statusFor = __webpack_exports__.SR;
+export { __webpack_exports__legacyArtifactsUrl as legacyArtifactsUrl, __webpack_exports__pickJob as pickJob, __webpack_exports__redirectUrl as redirectUrl, __webpack_exports__run as run, __webpack_exports__statusFor as statusFor };

--- a/index.js
+++ b/index.js
@@ -12,6 +12,48 @@ import * as github from '@actions/github'
 import fetch from 'node-fetch'
 import { pathToFileURL } from 'node:url'
 
+// Pick the job whose artifacts should be linked. A single-job workflow is
+// unambiguous; otherwise prefer a job the user asked for, and fall back to the
+// first one.
+export function pickJob(items, jobNames) {
+  if (items.length === 1) {
+    return items[0]
+  }
+  return items.find((job) => jobNames.includes(job.name)) ?? items[0]
+}
+
+// Turn a legacy OAuth target_url (…/gh/<org>/<repo>/<build>) into the v2
+// artifacts endpoint.
+export function legacyArtifactsUrl(target) {
+  const [orgId, repoId, buildId] = new URL(target).pathname.split('/').slice(-3)
+  return `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`
+}
+
+// Build the URL to link to: the requested artifact if anything was uploaded,
+// otherwise the CircleCI job itself (rewriting the domain only makes sense for
+// artifact URLs).
+export function redirectUrl(items, path, domain, fallback) {
+  if (!items.length) {
+    return fallback
+  }
+  // e.g., https://output.circle-artifacts.com/output/job/<uuid>/artifacts/0/doc/index.html
+  const job = items[0].url.split('/output/')[1].split('/artifacts/')[0]
+  return `https://${domain}/output/${job}/artifacts/${path}`
+}
+
+// The status reports whether the link is usable, not whether the CircleCI job
+// passed (gh-57): a job can fail late and still upload good artifacts, and the
+// job's own status already reports the failure.
+export function statusFor(payloadState, hasArtifacts, path) {
+  if (payloadState === 'pending') {
+    return {state: payloadState, description: 'Waiting for CircleCI ...'}
+  }
+  if (hasArtifacts) {
+    return {state: 'success', description: `Link to ${path}`}
+  }
+  return {state: 'failure', description: 'No artifacts found'}
+}
+
 // The context/fetch/octokit arguments exist so that tests can inject fakes;
 // in production the defaults are always used.
 export async function run({context = github.context, fetchFn = fetch, getOctokit = github.getOctokit} = {}) {
@@ -20,160 +62,81 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     const payload = context.payload
     const path = core.getInput('artifact-path', {required: true})
     const token = core.getInput('repo-token', {required: true})
-    let apiToken = core.getInput('api-token', {required: false})
-    let circleciJobs = core.getInput('circleci-jobs', {required: false})
-    if (circleciJobs === '') {
-      circleciJobs = 'build_docs,doc,build'
-    }
+    const apiToken = core.getInput('api-token', {required: false})
+    const jobNames = (core.getInput('circleci-jobs', {required: false}) || 'build_docs,doc,build').split(',')
 
-    // Split circleJobs into an array of job names
-    const circleciJobNames = circleciJobs.split(',')
-
-    //  Defines a variable to help prefix each job name with ci/circleci
-    const prepender = x => `ci/circleci: ${x}`
-    circleciJobs = circleciJobNames.map(prepender)
-    core.debug(`Considering CircleCI jobs named: ${circleciJobs}`)
-
-    if (circleciJobs.indexOf(payload.context) < 0) {
+    // Each job reports itself as a "ci/circleci: <name>" status context
+    const contexts = jobNames.map((name) => `ci/circleci: ${name}`)
+    core.debug(`Considering CircleCI jobs named: ${contexts}`)
+    if (!contexts.includes(payload.context)) {
       core.debug(`Ignoring context: ${payload.context}`)
       return
     }
 
-    // Read out 'state' (whether CircleCI process was successful or not), then
-    //  store in debug output along with the target_url
-    let state = payload.state
     core.debug(`context:    ${payload.context}`)
-    core.debug(`state:      ${state}`)
+    core.debug(`state:      ${payload.state}`)
     core.debug(`target_url: ${payload.target_url}`)
     // e.g., https://circleci.com/gh/mne-tools/mne-python/53315
     // e.g., https://circleci.com/gh/scientific-python/circleci-artifacts-redirector-action/94?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
-    // Set the new status
-    let artifacts_url = ''
     const target = payload.target_url.split('?')[0]   // strip any ?utm=…
+    let artifactsUrl = ''
     if (target.includes('/pipelines/circleci/') || target.includes('app.circleci.com/workflow/')) {
       // ───── New GitHub‑App URL ───────────────────────────────────────────
       // .../pipelines/circleci/<org‑id>/<project‑id>/<pipe‑seq>/workflows/<workflow‑id>
       // OR
       // .../workflow/<workflow-id>
-      const workflowId = target.split('/').pop()
+      const workflowId = target.split('/').at(-1)
       core.debug(`workflow: ${workflowId}`)
 
-      // 1. Get the jobs that belong to this workflow
-      const jobsRes = await fetchFn(
-        `https://circleci.com/api/v2/workflow/${workflowId}/job`
-      )
+      const jobsRes = await fetchFn(`https://circleci.com/api/v2/workflow/${workflowId}/job`)
       const jobs = await jobsRes.json()
       if (!jobs.items.length) {
         core.setFailed(`No jobs returned for workflow ${workflowId}`)
         return
       }
 
-      // 2. Identify and select the relevant job
-      // The simplest case is when a workflow contains only a single job, just
-      //  select the first entry
-      let job = null
-      if (jobs.items.length === 1) {
-        job = jobs.items[0]
-        core.debug('Workflow contains one job.')
-      }
-      // If there are multiple jobs in the workflow, select the first one that
-      //  matches one of the job names passed to the action.
-      else {
-        for (const jobItem of jobs.items) {
-          core.debug(`Checking job: ${jobItem.name} against ${circleciJobNames.join(',')}`)
-          if (circleciJobNames.includes(jobItem.name)) {
-            job = jobItem
-            break
-          }
-        }
-
-        // In the case where no matching job is found, use the first job
-        if (job == null) {
-          job = jobs.items[0]
-          core.debug(`No matching job found for ${circleciJobNames.join(', ')}. Using first job: ${job.name}`)
-        }
-      }
-
-      // Extract the project slug and job number from the selected job
-      const projectSlug = job.project_slug  // "circleci/<org‑id>/<project‑id>"
-      const jobNumber   = job.job_number
-
-      core.debug(`slug:  ${projectSlug}`)
-      core.debug(`job#:  ${jobNumber}`)
-
-      // 3. Construct the v2 artifacts endpoint
-      artifacts_url = `https://circleci.com/api/v2/project/${projectSlug}/${jobNumber}/artifacts`
+      const job = pickJob(jobs.items, jobNames)
+      core.debug(`Using job ${job.name} of ${jobs.items.map((item) => item.name).join(', ')}`)
+      core.debug(`slug:  ${job.project_slug}`)  // "circleci/<org‑id>/<project‑id>"
+      core.debug(`job#:  ${job.job_number}`)
+      artifactsUrl = `https://circleci.com/api/v2/project/${job.project_slug}/${job.job_number}/artifacts`
     } else {
-      // ───── Legacy OAuth URL (…/gh/<org>/<repo>/<build>) ────────────────
-      const parts    = target.split('/')
-      const orgId    = parts.slice(-3)[0]
-      const repoId   = parts.slice(-2)[0]
-      const buildId  = parts.slice(-1)[0]
+      artifactsUrl = legacyArtifactsUrl(target)
+    }
 
-      artifacts_url =
-        `https://circleci.com/api/v2/project/gh/${orgId}/${repoId}/${buildId}/artifacts`
-    }
-    core.debug(`Fetching JSON: ${artifacts_url}`)
-    if (apiToken == null || apiToken === '') {
-      apiToken = 'null'
-    }
-    else {
+    core.debug(`Fetching JSON: ${artifactsUrl}`)
+    if (apiToken !== '') {
       core.debug(`Successfully read CircleCI API token ${apiToken}`)
     }
-    const headers = {'Circle-Token': apiToken, 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
+    // CircleCI wants a literal "null" token for public projects
+    const headers = {'Circle-Token': apiToken || 'null', 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
     // e.g., https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts
-    const response = await fetchFn(artifacts_url, {headers})
+    const response = await fetchFn(artifactsUrl, {headers})
     const artifacts = await response.json()
     core.debug(`Artifacts JSON (status=${response.status}):`)
     core.debug(JSON.stringify(artifacts))
     // e.g., {"next_page_token":null,"items":[{"path":"test_artifacts/root_artifact.md","node_index":0,"url":"https://output.circle-artifacts.com/output/job/6fdfd148-31da-4a30-8e89-a20595696ca5/artifacts/0/test_artifacts/root_artifact.md"}]}
-    let url = ''
-    const hasArtifacts = artifacts.items.length > 0
-    if (hasArtifacts) {
-      url = `${artifacts.items[0].url.split('/artifacts/')[0]}/artifacts/${path}`
-      // Set root domain
-      const domain = core.getInput('domain')
-      url = `https://${domain}/output/${url.split('/output/')[1]}`
-    }
-    else {
-      // Nothing was uploaded, so the best we can do is link to the job itself.
-      // (Rewriting the domain only makes sense for artifact URLs.)
-      url = payload.target_url
-    }
+    const url = redirectUrl(artifacts.items, path, core.getInput('domain'), payload.target_url)
     core.debug(`Linking to: ${url}`)
     core.debug((new Date()).toTimeString())
     core.setOutput('url', url)
+
+    const {state, description} = statusFor(payload.state, artifacts.items.length > 0, path)
+    const jobTitle = core.getInput('job-title', {required: false}) || `${payload.context} artifact`
     const client = getOctokit(token)
-    // The status reports whether the link is usable, not whether the CircleCI
-    // job passed (gh-57): a job can fail late and still upload good artifacts,
-    // and the job's own status already reports the failure.
-    let description = ''
-    if (payload.state === 'pending') {
-      description = 'Waiting for CircleCI ...'
-    }
-    else if (hasArtifacts) {
-      state = 'success'
-      description = `Link to ${path}`
-    }
-    else {
-      state = 'failure'
-      description = 'No artifacts found'
-    }
-    let job_title = core.getInput('job-title', {required: false})
-    if (job_title === '') {
-      job_title = `${payload.context} artifact`
-    }
     return client.rest.repos.createCommitStatus({
       repo: context.repo.repo,
       owner: context.repo.owner,
       sha: payload.sha,
-      state: state,
+      state,
       target_url: url,
-      description: description,
-      context: job_title
+      description,
+      context: jobTitle
     })
   } catch (error) {
-    core.setFailed(error.message)
+    // Keep the failure itself readable; the stack is there with debug logging
+    core.debug(error.stack ?? String(error))
+    core.setFailed(error.message ?? String(error))
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { run } from './index.js'
+import { run, pickJob, legacyArtifactsUrl, redirectUrl, statusFor } from './index.js'
 
 const INPUTS = ['artifact-path', 'repo-token', 'api-token', 'circleci-jobs', 'job-title', 'domain']
 const OUTPUT_FILE = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'redirector-')), 'output.txt')
@@ -12,7 +12,7 @@ const ARTIFACT = {url: 'https://output.circle-artifacts.com/output/job/abc/artif
 // Run the action against fake CircleCI/GitHub backends. `bodies` are returned
 // by successive fetch() calls, and the recorded requests, the `url` output and
 // the commit status that was created are handed back for inspection.
-async function runAction({inputs = {}, payload = {}, bodies = []} = {}) {
+async function runAction({inputs = {}, payload = {}, bodies = [], fetchError} = {}) {
   fs.writeFileSync(OUTPUT_FILE, '')
   process.env.GITHUB_OUTPUT = OUTPUT_FILE
   for (const name of INPUTS) {
@@ -26,6 +26,9 @@ async function runAction({inputs = {}, payload = {}, bodies = []} = {}) {
   const requests = []
   const fetchFn = async (url, options) => {
     requests.push({url, options})
+    if (fetchError !== undefined) {
+      throw fetchError
+    }
     return {status: 200, json: async () => bodies.shift()}
   }
   let status = null
@@ -166,4 +169,42 @@ test('a bad response fails the job', async () => {
   assert.equal(status, null)
   assert.equal(process.exitCode, 1)  // core.setFailed()
   process.exitCode = 0
+})
+
+test('a thrown non-Error fails the job', async () => {
+  const {status} = await runAction({fetchError: 'kaboom'})
+  assert.equal(status, null)
+  assert.equal(process.exitCode, 1)  // core.setFailed()
+  process.exitCode = 0
+})
+
+// Unit tests for the pieces run() is built from
+
+test('pickJob', () => {
+  const lint = {name: 'lint'}
+  const docs = {name: 'docs'}
+  assert.equal(pickJob([lint], ['docs']), lint, 'a lone job is used even if unnamed')
+  assert.equal(pickJob([lint, docs], ['docs']), docs, 'a named job wins over an earlier one')
+  assert.equal(pickJob([lint, docs], ['nope']), lint, 'no match falls back to the first job')
+})
+
+test('legacyArtifactsUrl', () => {
+  assert.equal(
+    legacyArtifactsUrl('https://circleci.com/gh/mne-tools/mne-python/53315'),
+    'https://circleci.com/api/v2/project/gh/mne-tools/mne-python/53315/artifacts',
+  )
+})
+
+test('redirectUrl', () => {
+  assert.equal(
+    redirectUrl([ARTIFACT], 'doc/index.html', 'example.org', 'https://fallback'),
+    'https://example.org/output/job/abc/artifacts/doc/index.html',
+  )
+  assert.equal(redirectUrl([], 'doc/index.html', 'example.org', 'https://fallback'), 'https://fallback')
+})
+
+test('statusFor', () => {
+  assert.deepEqual(statusFor('pending', false, 'p'), {state: 'pending', description: 'Waiting for CircleCI ...'})
+  assert.deepEqual(statusFor('failure', true, 'p'), {state: 'success', description: 'Link to p'})
+  assert.deepEqual(statusFor('success', false, 'p'), {state: 'failure', description: 'No artifacts found'})
 })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "package": "ncc build index.js -o dist",
     "test": "eslint . && node --test",
-    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude='**/*.test.js' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info"
+    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude='**/*.test.js' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Tiers 3 and 4 from the modernization list, plus `.git-blame-ignore-revs`.

### Tier 3 — structure

- `run()` is now an orchestrator over four pure, individually tested helpers: `pickJob`, `legacyArtifactsUrl`, `redirectUrl`, and `statusFor`. Previously every behavior had to be exercised through env vars plus fake HTTP; these can be called directly.
- Modern idioms: `.includes()` over `indexOf(...) < 0`, `.at(-1)` over `.slice(-1)[0]`, and `new URL().pathname` over manual splitting for the legacy URL branch.
- Errors: the stack goes to `core.debug()` and `core.setFailed()` keeps the plain message. I originally proposed putting the stack *in* `setFailed`, but that turns a missing-input mistake into six lines of stack in the Actions UI — this way the stack is still available with `ACTIONS_STEP_DEBUG=true`.

### Tier 4 — CI hygiene

- Coverage floor: `--test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100`. Verified it actually bites by temporarily adding an uncovered function (exit 1) and removing it again (exit 0).
- All actions pinned to commit SHAs with the version in a trailing comment. Note this includes two `actions/checkout@master` uses in `status.yml`, which were unpinned entirely.
- `timeout-minutes: 5` on every job, `permissions: contents: read` on autofix, `permissions: {}` on the job that needs none.

### Blame

`.git-blame-ignore-revs` lists the style-only commit from #115. GitHub's blame view uses it automatically; the README documents the one-time `git config blame.ignoreRevsFile .git-blame-ignore-revs` for local use.

Tests: 17 (up from 12), 100% line/branch/function coverage. No behavior changes — the pre-existing integration tests all pass untouched, which is the main evidence that the refactor is faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)