### PR TITLE
FIX: Correctness and logging fixes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34592,6 +34592,7 @@ var __webpack_exports__ = {};
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
+  x6: () => (/* binding */ fetchJson),
   O$: () => (/* binding */ legacyArtifactsUrl),
   BH: () => (/* binding */ pickJob),
   Qc: () => (/* binding */ redirectUrl),
@@ -37304,7 +37305,7 @@ function exportVariable(name, val) {
  * ```
  */
 function core_setSecret(secret) {
-    issueCommand('add-mask', {}, secret);
+    command_issueCommand('add-mask', {}, secret);
 }
 /**
  * Prepends inputPath to the PATH (for this action and future actions)
@@ -44062,6 +44063,18 @@ function statusFor(payloadState, hasArtifacts, path) {
   return {state: 'failure', description: 'No artifacts found'}
 }
 
+// Fetch JSON from the CircleCI API, failing loudly on a non-2xx response.
+// Without this a 404 or a rate limit surfaces as a confusing "cannot read
+// properties of undefined" from the caller.
+async function fetchJson(fetchFn, url, options) {
+  const response = await fetchFn(url, options)
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`CircleCI API returned ${response.status} for ${url}: ${body.slice(0, 200)}`)
+  }
+  return response.json()
+}
+
 // The context/fetch/octokit arguments exist so that tests can inject fakes;
 // in production the defaults are always used.
 async function run({context = github_context, fetchFn = fetch, getOctokit = github_getOctokit} = {}) {
@@ -44071,7 +44084,16 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     const path = getInput('artifact-path', {required: true})
     const token = getInput('repo-token', {required: true})
     const apiToken = getInput('api-token', {required: false})
-    const jobNames = (getInput('circleci-jobs', {required: false}) || 'build_docs,doc,build').split(',')
+    if (apiToken !== '') {
+      // Keep the token out of the logs, including any future logging of it
+      core_setSecret(apiToken)
+      core_debug('Successfully read CircleCI API token')
+    }
+    // Tolerate spaces after the commas, e.g. "build_docs, doc"
+    const jobNames = (getInput('circleci-jobs', {required: false}) || 'build_docs,doc,build')
+      .split(',')
+      .map((name) => name.trim())
+      .filter((name) => name !== '')
 
     // Each job reports itself as a "ci/circleci: <name>" status context
     const contexts = jobNames.map((name) => `ci/circleci: ${name}`)
@@ -44084,6 +44106,11 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     core_debug(`context:    ${payload.context}`)
     core_debug(`state:      ${payload.state}`)
     core_debug(`target_url: ${payload.target_url}`)
+    if (!payload.target_url) {
+      // Some status events carry no URL at all, so there is nothing to link to
+      core_debug('Ignoring status with no target_url')
+      return
+    }
     // e.g., https://circleci.com/gh/mne-tools/mne-python/53315
     // e.g., https://circleci.com/gh/scientific-python/circleci-artifacts-redirector-action/94?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
     const target = payload.target_url.split('?')[0]   // strip any ?utm=…
@@ -44096,8 +44123,7 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
       const workflowId = target.split('/').at(-1)
       core_debug(`workflow: ${workflowId}`)
 
-      const jobsRes = await fetchFn(`https://circleci.com/api/v2/workflow/${workflowId}/job`)
-      const jobs = await jobsRes.json()
+      const jobs = await fetchJson(fetchFn, `https://circleci.com/api/v2/workflow/${workflowId}/job`)
       if (!jobs.items.length) {
         setFailed(`No jobs returned for workflow ${workflowId}`)
         return
@@ -44113,16 +44139,11 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     }
 
     core_debug(`Fetching JSON: ${artifactsUrl}`)
-    if (apiToken !== '') {
-      core_debug(`Successfully read CircleCI API token ${apiToken}`)
-    }
     // CircleCI wants a literal "null" token for public projects
     const headers = {'Circle-Token': apiToken || 'null', 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
     // e.g., https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts
-    const response = await fetchFn(artifactsUrl, {headers})
-    const artifacts = await response.json()
-    core_debug(`Artifacts JSON (status=${response.status}):`)
-    core_debug(JSON.stringify(artifacts))
+    const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
+    core_debug(`Artifacts JSON: ${JSON.stringify(artifacts)}`)
     // e.g., {"next_page_token":null,"items":[{"path":"test_artifacts/root_artifact.md","node_index":0,"url":"https://output.circle-artifacts.com/output/job/6fdfd148-31da-4a30-8e89-a20595696ca5/artifacts/0/test_artifacts/root_artifact.md"}]}
     const url = redirectUrl(artifacts.items, path, getInput('domain'), payload.target_url)
     core_debug(`Linking to: ${url}`)
@@ -44155,9 +44176,10 @@ if (import.meta.url === (0,external_node_url_.pathToFileURL)(process.argv[1]).hr
   run()
 }
 
+var __webpack_exports__fetchJson = __webpack_exports__.x6;
 var __webpack_exports__legacyArtifactsUrl = __webpack_exports__.O$;
 var __webpack_exports__pickJob = __webpack_exports__.BH;
 var __webpack_exports__redirectUrl = __webpack_exports__.Qc;
 var __webpack_exports__run = __webpack_exports__.eF;
 var __webpack_exports__statusFor = __webpack_exports__.SR;
-export { __webpack_exports__legacyArtifactsUrl as legacyArtifactsUrl, __webpack_exports__pickJob as pickJob, __webpack_exports__redirectUrl as redirectUrl, __webpack_exports__run as run, __webpack_exports__statusFor as statusFor };
+export { __webpack_exports__fetchJson as fetchJson, __webpack_exports__legacyArtifactsUrl as legacyArtifactsUrl, __webpack_exports__pickJob as pickJob, __webpack_exports__redirectUrl as redirectUrl, __webpack_exports__run as run, __webpack_exports__statusFor as statusFor };

--- a/index.js
+++ b/index.js
@@ -54,6 +54,18 @@ export function statusFor(payloadState, hasArtifacts, path) {
   return {state: 'failure', description: 'No artifacts found'}
 }
 
+// Fetch JSON from the CircleCI API, failing loudly on a non-2xx response.
+// Without this a 404 or a rate limit surfaces as a confusing "cannot read
+// properties of undefined" from the caller.
+export async function fetchJson(fetchFn, url, options) {
+  const response = await fetchFn(url, options)
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`CircleCI API returned ${response.status} for ${url}: ${body.slice(0, 200)}`)
+  }
+  return response.json()
+}
+
 // The context/fetch/octokit arguments exist so that tests can inject fakes;
 // in production the defaults are always used.
 export async function run({context = github.context, fetchFn = fetch, getOctokit = github.getOctokit} = {}) {
@@ -63,7 +75,16 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     const path = core.getInput('artifact-path', {required: true})
     const token = core.getInput('repo-token', {required: true})
     const apiToken = core.getInput('api-token', {required: false})
-    const jobNames = (core.getInput('circleci-jobs', {required: false}) || 'build_docs,doc,build').split(',')
+    if (apiToken !== '') {
+      // Keep the token out of the logs, including any future logging of it
+      core.setSecret(apiToken)
+      core.debug('Successfully read CircleCI API token')
+    }
+    // Tolerate spaces after the commas, e.g. "build_docs, doc"
+    const jobNames = (core.getInput('circleci-jobs', {required: false}) || 'build_docs,doc,build')
+      .split(',')
+      .map((name) => name.trim())
+      .filter((name) => name !== '')
 
     // Each job reports itself as a "ci/circleci: <name>" status context
     const contexts = jobNames.map((name) => `ci/circleci: ${name}`)
@@ -76,6 +97,11 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     core.debug(`context:    ${payload.context}`)
     core.debug(`state:      ${payload.state}`)
     core.debug(`target_url: ${payload.target_url}`)
+    if (!payload.target_url) {
+      // Some status events carry no URL at all, so there is nothing to link to
+      core.debug('Ignoring status with no target_url')
+      return
+    }
     // e.g., https://circleci.com/gh/mne-tools/mne-python/53315
     // e.g., https://circleci.com/gh/scientific-python/circleci-artifacts-redirector-action/94?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
     const target = payload.target_url.split('?')[0]   // strip any ?utm=…
@@ -88,8 +114,7 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
       const workflowId = target.split('/').at(-1)
       core.debug(`workflow: ${workflowId}`)
 
-      const jobsRes = await fetchFn(`https://circleci.com/api/v2/workflow/${workflowId}/job`)
-      const jobs = await jobsRes.json()
+      const jobs = await fetchJson(fetchFn, `https://circleci.com/api/v2/workflow/${workflowId}/job`)
       if (!jobs.items.length) {
         core.setFailed(`No jobs returned for workflow ${workflowId}`)
         return
@@ -105,16 +130,11 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     }
 
     core.debug(`Fetching JSON: ${artifactsUrl}`)
-    if (apiToken !== '') {
-      core.debug(`Successfully read CircleCI API token ${apiToken}`)
-    }
     // CircleCI wants a literal "null" token for public projects
     const headers = {'Circle-Token': apiToken || 'null', 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
     // e.g., https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts
-    const response = await fetchFn(artifactsUrl, {headers})
-    const artifacts = await response.json()
-    core.debug(`Artifacts JSON (status=${response.status}):`)
-    core.debug(JSON.stringify(artifacts))
+    const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
+    core.debug(`Artifacts JSON: ${JSON.stringify(artifacts)}`)
     // e.g., {"next_page_token":null,"items":[{"path":"test_artifacts/root_artifact.md","node_index":0,"url":"https://output.circle-artifacts.com/output/job/6fdfd148-31da-4a30-8e89-a20595696ca5/artifacts/0/test_artifacts/root_artifact.md"}]}
     const url = redirectUrl(artifacts.items, path, core.getInput('domain'), payload.target_url)
     core.debug(`Linking to: ${url}`)

--- a/index.test.js
+++ b/index.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { run, pickJob, legacyArtifactsUrl, redirectUrl, statusFor } from './index.js'
+import { run, pickJob, legacyArtifactsUrl, redirectUrl, statusFor, fetchJson } from './index.js'
 
 const INPUTS = ['artifact-path', 'repo-token', 'api-token', 'circleci-jobs', 'job-title', 'domain']
 const OUTPUT_FILE = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'redirector-')), 'output.txt')
@@ -12,7 +12,7 @@ const ARTIFACT = {url: 'https://output.circle-artifacts.com/output/job/abc/artif
 // Run the action against fake CircleCI/GitHub backends. `bodies` are returned
 // by successive fetch() calls, and the recorded requests, the `url` output and
 // the commit status that was created are handed back for inspection.
-async function runAction({inputs = {}, payload = {}, bodies = [], fetchError} = {}) {
+async function runAction({inputs = {}, payload = {}, bodies = [], fetchError, httpStatus = 200} = {}) {
   fs.writeFileSync(OUTPUT_FILE, '')
   process.env.GITHUB_OUTPUT = OUTPUT_FILE
   for (const name of INPUTS) {
@@ -29,7 +29,12 @@ async function runAction({inputs = {}, payload = {}, bodies = [], fetchError} = 
     if (fetchError !== undefined) {
       throw fetchError
     }
-    return {status: 200, json: async () => bodies.shift()}
+    return {
+      ok: httpStatus < 400,
+      status: httpStatus,
+      json: async () => bodies.shift(),
+      text: async () => JSON.stringify(bodies.shift()),
+    }
   }
   let status = null
   const getOctokit = () => ({rest: {repos: {createCommitStatus: async (s) => { status = s }}}})
@@ -46,6 +51,20 @@ async function runAction({inputs = {}, payload = {}, bodies = [], fetchError} = 
   await run({context, fetchFn, getOctokit})
   const url = fs.readFileSync(OUTPUT_FILE, 'utf8').split(os.EOL)[1]
   return {requests, url, status}
+}
+
+// Collect everything written to stdout (the ::debug::/::error:: workflow
+// commands) while fn runs.
+async function captureStdout(fn) {
+  const written = []
+  const original = process.stdout.write
+  process.stdout.write = (chunk) => { written.push(String(chunk)); return true }
+  try {
+    await fn()
+  } finally {
+    process.stdout.write = original
+  }
+  return written.join('')
 }
 
 test('legacy CircleCI URL', async () => {
@@ -207,4 +226,66 @@ test('statusFor', () => {
   assert.deepEqual(statusFor('pending', false, 'p'), {state: 'pending', description: 'Waiting for CircleCI ...'})
   assert.deepEqual(statusFor('failure', true, 'p'), {state: 'success', description: 'Link to p'})
   assert.deepEqual(statusFor('success', false, 'p'), {state: 'failure', description: 'No artifacts found'})
+})
+
+// Tier 1 fixes
+
+test('the api token is masked and never logged', async () => {
+  process.env.RUNNER_DEBUG = '1'  // make core.debug() actually write
+  let out
+  try {
+    out = await captureStdout(
+      () => runAction({inputs: {'api-token': 'super-secret'}, bodies: [{items: [ARTIFACT]}]}))
+  } finally {
+    delete process.env.RUNNER_DEBUG
+  }
+  assert.ok(out.includes('::add-mask::super-secret'), 'the token is registered as a secret')
+  assert.ok(
+    !out.split('::add-mask::super-secret').join('').includes('super-secret'),
+    'the token appears nowhere else in the log',
+  )
+})
+
+test('job names are trimmed', async () => {
+  const {requests} = await runAction({
+    inputs: {'circleci-jobs': 'build_docs, docs'},
+    payload: {context: 'ci/circleci: docs'},
+    bodies: [{items: [ARTIFACT]}],
+  })
+  assert.equal(requests.length, 1, 'a name with a leading space still matches')
+})
+
+test('a status with no target_url is ignored', async () => {
+  const {requests, status} = await runAction({payload: {target_url: null}})
+  assert.deepEqual(requests, [])
+  assert.equal(status, null)
+  assert.equal(process.exitCode, 0, 'ignored, not failed')
+})
+
+test('an HTTP error fails the job with a useful message', async () => {
+  let result
+  const out = await captureStdout(async () => {
+    result = await runAction({httpStatus: 429, bodies: [{message: 'slow down'}]})
+  })
+  assert.equal(result.status, null)
+  assert.equal(process.exitCode, 1)  // core.setFailed()
+  process.exitCode = 0
+  assert.match(out, /::error::CircleCI API returned 429 for /)
+  assert.match(out, /slow down/)
+})
+
+test('fetchJson', async () => {
+  const okResponse = {ok: true, status: 200, json: async () => ({items: []})}
+  assert.deepEqual(await fetchJson(async () => okResponse, 'https://x'), {items: []})
+
+  const badResponse = {ok: false, status: 404, text: async () => 'no such project'}
+  await assert.rejects(
+    () => fetchJson(async () => badResponse, 'https://x'),
+    /returned 404 for https:\/\/x: no such project/,
+    'the status and body make it into the message',
+  )
+
+  // An unreadable body should not mask the status code
+  const unreadable = {ok: false, status: 500, text: async () => { throw new Error('nope') }}
+  await assert.rejects(() => fetchJson(async () => unreadable, 'https://x'), /returned 500/)
 })


### PR DESCRIPTION
Tier 1 from the modernization list — the four items that are actual bugs rather than cleanups.

### The CircleCI API token was logged in plain text

```js
core.debug(`Successfully read CircleCI API token ${apiToken}`)
```

The README tells users to set `ACTIONS_STEP_DEBUG=true` when troubleshooting, so this was a live path to leaking a private-repo CircleCI token into logs any org member can read. Now `core.setSecret(apiToken)` is called as soon as it is read — which masks it in *all* subsequent output, not just this one line — and the message no longer includes the value.

### Non-2xx responses were used as if they were JSON

Both fetches called `.json()` without checking the response, so a 404 or a rate limit surfaced as `Cannot read properties of undefined (reading 'items')`. A new `fetchJson()` helper throws with the status code and a slice of the body instead, which should make the "doesn't work in our project" reports diagnosable.

### `circleci-jobs` was not trimmed

`circleci-jobs: "build_docs, doc"` produced `" doc"`, which silently never matched any status context.

### A missing `target_url` failed the run

Some status events carry no URL; `.split()` on it threw and the action reported a failure. It is now ignored the same way an unmatched context is.

### Verification

22 tests, 100% line/branch/function coverage. Each fix was mutation-tested — reverting it individually makes exactly the intended test fail:

| Mutation | Failing test |
|---|---|
| remove `core.setSecret` | `the api token is masked and never logged` |
| remove `.trim()` | `job names are trimmed` |
| remove `target_url` guard | `a status with no target_url is ignored` |
| remove `!response.ok` | `an HTTP error fails the job with a useful message`, `fetchJson` |

The masking test asserts both that `::add-mask::` is emitted *and* that the token appears nowhere else in captured stdout. Note the HTTP-error test asserts on the message text specifically — without `fetchJson` the action still fails, just uninformatively, so a status-only assertion would not have caught the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)