### PR TITLE
FIX: Do not send a bogus Circle-Token header

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44139,8 +44139,12 @@ async function run({context = github_context, fetchFn = fetch, getOctokit = gith
     }
 
     core_debug(`Fetching JSON: ${artifactsUrl}`)
-    // CircleCI wants a literal "null" token for public projects
-    const headers = {'Circle-Token': apiToken || 'null', 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
+    // Only send a token when we have one: CircleCI rejects a bogus token with
+    // a 401 even for public projects, but is happy with no token at all
+    const headers = {'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
+    if (apiToken !== '') {
+      headers['Circle-Token'] = apiToken
+    }
     // e.g., https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts
     const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
     core_debug(`Artifacts JSON: ${JSON.stringify(artifacts)}`)

--- a/index.js
+++ b/index.js
@@ -130,8 +130,12 @@ export async function run({context = github.context, fetchFn = fetch, getOctokit
     }
 
     core.debug(`Fetching JSON: ${artifactsUrl}`)
-    // CircleCI wants a literal "null" token for public projects
-    const headers = {'Circle-Token': apiToken || 'null', 'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
+    // Only send a token when we have one: CircleCI rejects a bogus token with
+    // a 401 even for public projects, but is happy with no token at all
+    const headers = {'accept': 'application/json', 'user-agent': 'curl/7.85.0'}
+    if (apiToken !== '') {
+      headers['Circle-Token'] = apiToken
+    }
     // e.g., https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts
     const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
     core.debug(`Artifacts JSON: ${JSON.stringify(artifacts)}`)

--- a/index.test.js
+++ b/index.test.js
@@ -71,7 +71,7 @@ test('legacy CircleCI URL', async () => {
   const {requests, url, status} = await runAction({bodies: [{items: [ARTIFACT]}]})
   assert.equal(requests.length, 1)
   assert.equal(requests[0].url, 'https://circleci.com/api/v2/project/gh/scientific-python/circleci-artifacts-redirector-action/94/artifacts')
-  assert.equal(requests[0].options.headers['Circle-Token'], 'null')
+  assert.ok(!('Circle-Token' in requests[0].options.headers), 'no token header without an api-token')
   assert.equal(url, 'https://output.circle-artifacts.com/output/job/abc/artifacts/doc/index.html')
   assert.deepEqual(status, {
     repo: 'circleci-artifacts-redirector-action',


### PR DESCRIPTION
**This is a live bug for every public-repo user who does not set `api-token`, which is the documented default.** Found while verifying the native-fetch swap in #118 against the real API.

With no `api-token`, the action sends `Circle-Token: null` (the literal string). CircleCI rejects that:

```
no header             : 200
Circle-Token: null    : 401   {"message":"Invalid token provided."}
Circle-Token: <empty> : 200
real token            : 200
```

So the artifacts request 401s, `.items` is missing, and the run fails. The fix is to send the header only when a token was actually supplied.

### Why CI never caught this

`.github/workflows/status.yml` passes `api-token: ${{ secrets.CIRCLECI_TOKEN }}`, so this repo's own self-test always takes the authenticated path. The tokenless path that public-repo users depend on was never exercised — worth considering whether the self-test should cover both.

### Verification

Running `run()` against the live CircleCI API (job 361, no token, only `getOctokit` faked):

```
status state      : success
status target_url : https://output.circle-artifacts.com/output/job/982be.../root_artifact.md
```

and that URL returns `200`. Before the fix the same script failed with `CircleCI API returned 401`. The unit test now asserts the header is absent rather than `'null'`; 22 tests, 100% coverage.

Note this PR is branched off `master`, not off #118, so it can go in independently — but it should be in the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)