### PR TITLE
TST: Cover the tokenless path in the self-test

### DIFF
--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -35,11 +35,40 @@ jobs:
           job-title: "See artifact here (status)!"
         id: run-circleci-artifacts-redirector
 
+  # The job above passes an api-token, so it only ever exercises the
+  # authenticated path. Public repos typically set no api-token at all, and
+  # that path broke without anyone noticing (gh-119), so cover it too.
+  circleci_artifacts_redirector_no_token_job:
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: "${{ github.event.context == 'ci/circleci: build' }}"
+    name: CircleCI artifacts redirector status (no api-token)
+    outputs:
+      url: ${{ steps.run-circleci-artifacts-redirector-no-token.outputs.url }}
+    steps:
+      # WARNING!
+      # This repo uses the action in its own root directory.
+      # GitHub-action users should not do this!
+      # See README.md for usage instructions.
+      - name: Checkout repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.event.sha }}
+      - name: GitHub Action step
+        uses: ./
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/test_artifacts/root_artifact.md
+          job-title: "See artifact here (no api-token)!"
+        id: run-circleci-artifacts-redirector-no-token
+
   use_outputs_status_job:
     permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [circleci_artifacts_redirector_status_job]
+    needs: [circleci_artifacts_redirector_status_job, circleci_artifacts_redirector_no_token_job]
     name: Use the status output
     if: github.event.state != 'pending'
     steps:
@@ -53,3 +82,5 @@ jobs:
           echo ${{ github.event.sha }}
       - name: Check the URL
         run: curl -L --fail ${{ needs.circleci_artifacts_redirector_status_job.outputs.url }} | grep ${{ github.event.sha }}
+      - name: Check the URL from the run without an api-token
+        run: curl -L --fail ${{ needs.circleci_artifacts_redirector_no_token_job.outputs.url }} | grep ${{ github.event.sha }}


### PR DESCRIPTION
Closes the CI hole that let #119 through.

`status.yml` only ever ran the action with `api-token: ${{ secrets.CIRCLECI_TOKEN }}`, so the authenticated path was covered and the tokenless path — the one most public repos actually use — was not. That is why `Circle-Token: null` could start 401ing without CI turning red.

Adds `circleci_artifacts_redirector_no_token_job`: identical to the existing job but with no `api-token`, posting under the distinct title "See artifact here (no api-token)!" so the two statuses don't collide. `use_outputs_status_job` now depends on both and curls both URLs, grepping for the commit SHA in the artifact.

### Caveat on validation

This cannot be exercised by its own PR. The workflow only fires on `status` events, which arrive when CircleCI builds — and this branch lives on a fork, so no `ci/circleci: build` status is posted upstream. It will run for real on the first CircleCI build of `master` after merge.

What I could verify: the YAML parses, both `needs.*` references resolve to real job ids, the new job passes exactly `artifact-path`, `job-title`, `repo-token` (no `api-token`), and yamllint passes. The underlying behavior was verified live in #119 — running the action tokenless against the real API produces a `success` status and a URL that returns 200.

So the first master build after merging is worth a glance: two green "See artifact here" statuses instead of one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)