### PR TITLE
MAINT: Sync the pre-commit ESLint pins with package.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,15 @@ repos:
       - id: yamllint
         args: [--strict, -c, .yamllint.yml]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v10.4.1'
+    # Keep rev and additional_dependencies in sync with the devDependencies in
+    # package.json, otherwise this hook lints with a different ESLint than
+    # `npm run lint` and CI do. Dependabot updates package.json but not this
+    # file, so bump both when it opens an ESLint PR.
+    rev: 'v10.8.0'
     hooks:
     -   id: eslint
         files: ^index(\.test)?\.js$
         additional_dependencies:
-        - globals@17.6.0
-        - eslint@10.4.1
+        - globals@17.8.0
+        - eslint@10.8.0
         - '@eslint/js@10.0.1'
-        - '@eslint/eslintrc@3.3.5'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@vercel/ncc": "^0.44.0",
-        "eslint": "^10.4.1",
-        "globals": "^17.6.0"
+        "eslint": "^10.8.0",
+        "globals": "^17.8.0"
       },
       "engines": {
         "node": ">=24"
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -599,7 +599,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -623,7 +623,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vercel/ncc": "^0.44.0",
-    "eslint": "^10.4.1",
-    "globals": "^17.6.0"
+    "eslint": "^10.8.0",
+    "globals": "^17.8.0"
   },
   "private": true,
   "engines": {


### PR DESCRIPTION
Keeps the `mirrors-eslint` hook (no local/system hook), just brings its pins back in line.

The hook was pinned at `v10.4.1` while the project ran 10.6.0, and its `additional_dependencies` still listed `@eslint/eslintrc@3.3.5` — which #118 removed from `eslint.config.mjs` entirely — plus `globals@17.6.0`. So `pre-commit run eslint` and `npm run lint` were linting with different ESLint versions and different dependency sets.

- `rev` and `eslint` -> 10.8.0, `globals` -> 17.8.0, matching `package.json` (also bumped to the same versions here)
- dropped the stale `@eslint/eslintrc` pin
- added a comment saying the two files must be bumped together, since dependabot updates `package.json` but not `.pre-commit-config.yaml`

### Verification

The hook rebuilt its environment with the new pins and passes. To confirm it is really applying *our* config rather than falling back to a default after the `eslintrc` removal, I appended `var styleViolation = "double quotes";` and ran the hook:

```
173:1   error  Unexpected var, use let or const instead             no-var
173:5   error  'styleViolation' is assigned a value but never used  no-unused-vars
173:22  error  Strings must use singlequote                         quotes
173:37  error  Extra semicolon                                      semi
```

All four project rules fire. Reverted, hook passes, `npm run lint` passes, 22 tests green.

Note this leaves a manual sync point: when dependabot bumps ESLint in `package.json`, `.pre-commit-config.yaml` needs the same bump by hand. A `repo: local` hook would remove that entirely, but that was deliberately not taken here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)