### PR TITLE
PERF: Stop serializing the artifacts payload on every request; add tools/cf-usage.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ GitHub commit status:
 | `index.js` | GitHub Action entry point (`@actions/core`, `@actions/github`) |
 | `worker/index.js` | GitHub App entry point: a Cloudflare Worker handling `status` webhooks |
 | `dist/index.js` | the bundle the action actually runs; **committed**, built by `ncc` |
+| `tools/cf-usage.py` | Cloudflare usage report for the deployed Worker (stdlib only) |
 
 Keep logic in `src/`. Anything added to only one front end will drift; that is
 the whole reason the split exists.
@@ -27,6 +28,7 @@ npm run coverage  # the same, with a hard 100% line/branch/function floor
 npx ncc build index.js -o dist   # after ANY change to index.js or src/
 pre-commit run --all-files       # yamllint + eslint, as CI runs them
 npx wrangler deploy              # after ANY change to worker/ or src/
+tools/cf-usage.py [days]         # deployed Worker usage vs the free-tier limits
 ```
 
 CI enforces 100% coverage. New code needs tests, or `/* node:coverage
@@ -108,6 +110,45 @@ Deploy: `npx wrangler deploy`. Secrets: `APP_ID`, `PRIVATE_KEY`,
   a config exists, cached for 10 minutes.
 - Responses are the diagnostic surface: the App's Advanced → Recent Deliveries
   tab shows exactly which stage a delivery reached.
+
+### CPU is the limit that binds, not requests
+
+The free plan allows 100,000 requests/day but only **10 ms of CPU per
+invocation** (I/O does not count, so awaiting GitHub and CircleCI is free).
+Requests are a non-issue — measured traffic is well under 1% of the daily cap,
+with ~200x headroom — while the observed CPU p99 already sits near 10 ms. When
+a Worker consistently exceeds it, Cloudflare terminates the invocation with
+error 1102; occasional overruns are tolerated.
+
+What actually costs CPU here, measured:
+
+| Operation | Cost |
+|---|---|
+| `JSON.parse` of the artifacts listing (~1 MB, unavoidable) | ~1.5 ms |
+| `JSON.stringify` of that same listing | ~2.8 ms |
+| RSA import + JWT sign (only on a token cache miss) | ~1.0 ms |
+| HMAC import + webhook signature verify | ~0.08 ms |
+
+A large docs build lists thousands of files (scikit-learn: 3,904 artifacts,
+982 KB; MNE-Python: 3,290, 755 KB), so **anything that touches the whole
+artifacts payload is the most expensive thing the Worker does** — more than the
+crypto, by a lot.
+
+Hence: `src/core.js` passes a **thunk** to `log` for messages that are expensive
+to build, and the Worker's `log` is a no-op that never calls it. Do not "simplify"
+that back into a template string — a no-op logger still evaluates its argument,
+which is exactly the bug it fixes. `index.js` resolves the thunk only when
+`core.isDebug()`.
+
+Two tests pin this down (`index.test.js`, `worker/index.test.js`): the fake
+artifacts payload carries a `toJSON` hook that counts serializations, and the
+tests assert it is never called. That is a deterministic tripwire for the
+specific wasteful operation; asserting on elapsed milliseconds would be flaky.
+Add the same guard for any new code that could walk the payload.
+
+Check real usage with `tools/cf-usage.py` (uses the token `wrangler login`
+already stored; no extra API token needed). It reports CPU quantiles and
+invocation outcomes, and flags a p99 over the limit.
 
 ## Where things stand (2026-07-28)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29149,6 +29149,7 @@ var __webpack_exports__ = {};
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
+  Y: () => (/* binding */ index_debug),
   e: () => (/* binding */ run)
 });
 
@@ -36558,6 +36559,10 @@ async function artifactsUrlFor(target, jobNames, fetchFn, log) {
 // The whole job: from a status payload plus config, produce the commit status
 // to create, or null when this event is none of our business. Throws when
 // CircleCI cannot be reached or returns something unusable.
+//
+// `log` is called with either a string or, for messages that are expensive to
+// build, a thunk returning one. A sink that discards debug output must simply
+// not call the thunk; see the CPU note below.
 async function resolveStatus({payload, config, fetchFn = globalThis.fetch, log = () => {}}) {
   // Each job reports itself as a "ci/circleci: <name>" status context
   const contexts = config.jobNames.map((name) => `ci/circleci: ${name}`)
@@ -36588,7 +36593,12 @@ async function resolveStatus({payload, config, fetchFn = globalThis.fetch, log =
     headers['Circle-Token'] = config.apiToken
   }
   const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
-  log(`Artifacts JSON: ${JSON.stringify(artifacts)}`)
+  // Thunk, not a string: a docs build lists thousands of files, so this payload
+  // runs to ~1 MB and serializing it costs about twice what parsing the
+  // response did (~2.8 ms vs ~1.5 ms for scikit-learn). The Worker gets 10 ms
+  // of CPU per request, and its `log` is a no-op, so it must never pay for a
+  // message nobody reads.
+  log(() => `Artifacts JSON: ${JSON.stringify(artifacts)}`)
 
   const url = redirectUrl(artifacts.items, config.path, config.domain, payload.target_url)
   const {state, description} = statusFor(payload.state, artifacts.items.length > 0, config.path)
@@ -36619,6 +36629,18 @@ async function resolveStatus({payload, config, fetchFn = globalThis.fetch, log =
 
 
 
+// src/core.js passes a thunk for debug messages that are expensive to build, so
+// that a sink which throws the output away never builds them. core.debug emits
+// the ::debug:: command whether or not the runner is in debug mode, so resolve
+// the thunk only when someone will actually read the result.
+function index_debug(message) {
+  if (typeof message !== 'function') {
+    core_debug(message)
+  } else if (isDebug()) {
+    core_debug(message())
+  }
+}
+
 // The context/fetch/octokit arguments exist so that tests can inject fakes;
 // in production the defaults are always used.
 async function run({context = github_context, fetchFn = globalThis.fetch, getOctokit = github_getOctokit} = {}) {
@@ -36640,7 +36662,7 @@ async function run({context = github_context, fetchFn = globalThis.fetch, getOct
       core_debug('Successfully read CircleCI API token')
     }
 
-    const status = await resolveStatus({payload, config, fetchFn, log: core_debug})
+    const status = await resolveStatus({payload, config, fetchFn, log: index_debug})
     if (status === null) {
       return
     }
@@ -36672,5 +36694,6 @@ if (import.meta.url === (0,external_node_url_.pathToFileURL)(process.argv[1]).hr
 }
 /* node:coverage enable */
 
+var __webpack_exports__debug = __webpack_exports__.Y;
 var __webpack_exports__run = __webpack_exports__.e;
-export { __webpack_exports__run as run };
+export { __webpack_exports__debug as debug, __webpack_exports__run as run };

--- a/index.js
+++ b/index.js
@@ -16,6 +16,18 @@ import { pathToFileURL } from 'node:url'
 import { normalizeConfig } from './src/config.js'
 import { resolveStatus } from './src/core.js'
 
+// src/core.js passes a thunk for debug messages that are expensive to build, so
+// that a sink which throws the output away never builds them. core.debug emits
+// the ::debug:: command whether or not the runner is in debug mode, so resolve
+// the thunk only when someone will actually read the result.
+export function debug(message) {
+  if (typeof message !== 'function') {
+    core.debug(message)
+  } else if (core.isDebug()) {
+    core.debug(message())
+  }
+}
+
 // The context/fetch/octokit arguments exist so that tests can inject fakes;
 // in production the defaults are always used.
 export async function run({context = github.context, fetchFn = globalThis.fetch, getOctokit = github.getOctokit} = {}) {
@@ -37,7 +49,7 @@ export async function run({context = github.context, fetchFn = globalThis.fetch,
       core.debug('Successfully read CircleCI API token')
     }
 
-    const status = await resolveStatus({payload, config, fetchFn, log: core.debug})
+    const status = await resolveStatus({payload, config, fetchFn, log: debug})
     if (status === null) {
       return
     }

--- a/index.test.js
+++ b/index.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { run } from './index.js'
+import { debug, run } from './index.js'
 import { pickJob, legacyArtifactsUrl, redirectUrl, statusFor, fetchJson, resolveStatus } from './src/core.js'
 import { normalizeConfig } from './src/config.js'
 
@@ -300,6 +300,70 @@ test('resolveStatus works without a logger', async () => {
     fetchFn,
   })
   assert.equal(status.url, 'https://output.circle-artifacts.com/output/job/abc/artifacts/doc/index.html')
+})
+
+// CPU budget (see CLAUDE.md): the Worker gets 10 ms of CPU per request and the
+// artifacts payload is ~1 MB for a large docs build, so no debug message may be
+// built unless something is going to read it. A `toJSON` hook is a precise
+// tripwire for that -- JSON.stringify() cannot serialize the payload without
+// calling it -- where asserting on elapsed milliseconds would just be flaky.
+const countingArtifacts = () => {
+  const payload = {items: [ARTIFACT], serialized: 0}
+  payload.toJSON = () => { payload.serialized++; return {items: [ARTIFACT]} }
+  return payload
+}
+
+const resolveWith = (artifacts, log) => resolveStatus({
+  payload: {context: 'ci/circleci: build', state: 'success', target_url: 'https://circleci.com/gh/o/r/1'},
+  config: normalizeConfig({'artifact-path': 'doc/index.html'}),
+  fetchFn: async () => ({ok: true, status: 200, json: async () => artifacts}),
+  log,
+})
+
+test('the artifacts payload is not serialized when the log discards it', async () => {
+  const artifacts = countingArtifacts()
+  await resolveWith(artifacts, () => {})   // the Worker's logger
+  assert.equal(artifacts.serialized, 0, 'serializing costs ~2x parsing the response')
+
+  const bare = countingArtifacts()
+  await resolveWith(bare)                  // and with no logger at all
+  assert.equal(bare.serialized, 0)
+})
+
+test('a logger that resolves thunks still gets the full payload', async () => {
+  const artifacts = countingArtifacts()
+  const lines = []
+  await resolveWith(artifacts, (m) => lines.push(typeof m === 'function' ? m() : m))
+  assert.equal(artifacts.serialized, 1, 'built once, not once per line')
+  assert.ok(lines.some((line) => line.startsWith('Artifacts JSON: {')), 'debugging is unaffected')
+})
+
+test('debug() only builds an expensive message when the runner wants it', async () => {
+  const thunk = () => { calls++; return 'expensive' }
+  let calls = 0
+
+  delete process.env.RUNNER_DEBUG
+  let out = await captureStdout(async () => debug(thunk))
+  assert.equal(calls, 0, 'not built when debug logging is off')
+  assert.equal(out, '')
+
+  process.env.RUNNER_DEBUG = '1'
+  try {
+    out = await captureStdout(async () => {
+      debug(thunk)
+      debug('plain string')
+    })
+  } finally {
+    delete process.env.RUNNER_DEBUG
+  }
+  assert.equal(calls, 1)
+  assert.match(out, /::debug::expensive/)
+  assert.match(out, /::debug::plain string/)
+})
+
+test('debug() passes plain strings through whatever the runner is doing', async () => {
+  const out = await captureStdout(async () => debug('always emitted'))
+  assert.match(out, /::debug::always emitted/, 'core.debug decides, as it always did')
 })
 
 test('post-pending: false skips the pending status entirely', async () => {

--- a/src/core.js
+++ b/src/core.js
@@ -83,6 +83,10 @@ export async function artifactsUrlFor(target, jobNames, fetchFn, log) {
 // The whole job: from a status payload plus config, produce the commit status
 // to create, or null when this event is none of our business. Throws when
 // CircleCI cannot be reached or returns something unusable.
+//
+// `log` is called with either a string or, for messages that are expensive to
+// build, a thunk returning one. A sink that discards debug output must simply
+// not call the thunk; see the CPU note below.
 export async function resolveStatus({payload, config, fetchFn = globalThis.fetch, log = () => {}}) {
   // Each job reports itself as a "ci/circleci: <name>" status context
   const contexts = config.jobNames.map((name) => `ci/circleci: ${name}`)
@@ -113,7 +117,12 @@ export async function resolveStatus({payload, config, fetchFn = globalThis.fetch
     headers['Circle-Token'] = config.apiToken
   }
   const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
-  log(`Artifacts JSON: ${JSON.stringify(artifacts)}`)
+  // Thunk, not a string: a docs build lists thousands of files, so this payload
+  // runs to ~1 MB and serializing it costs about twice what parsing the
+  // response did (~2.8 ms vs ~1.5 ms for scikit-learn). The Worker gets 10 ms
+  // of CPU per request, and its `log` is a no-op, so it must never pay for a
+  // message nobody reads.
+  log(() => `Artifacts JSON: ${JSON.stringify(artifacts)}`)
 
   const url = redirectUrl(artifacts.items, config.path, config.domain, payload.target_url)
   const {state, description} = statusFor(payload.state, artifacts.items.length > 0, config.path)

--- a/tools/cf-usage.py
+++ b/tools/cf-usage.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Report Cloudflare Workers usage for this Worker against the free-tier quota.
+
+Reads the OAuth token wrangler already stored, so it needs no extra API token:
+`wrangler login` is the only setup. Usage: ./cf-usage.py [days]  (default 7)
+"""
+import json
+import re
+import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+GRAPHQL = 'https://api.cloudflare.com/client/v4/graphql'
+DAILY_FREE_REQUESTS = 100_000  # Workers free plan, per UTC day
+FREE_CPU_LIMIT_US = 10_000  # 10 ms per invocation; over it, status is exceededCpu
+CONFIG = Path('~/.config/.wrangler/config/default.toml').expanduser()
+
+
+def token():
+    if not CONFIG.exists():
+        sys.exit(f'{CONFIG} does not exist; run `npx wrangler login`')
+    m = re.search(r'oauth_token\s*=\s*"([^"]+)"', CONFIG.read_text())
+    if not m:
+        sys.exit(f'no oauth_token in {CONFIG}; run `npx wrangler login`')
+    return m.group(1)
+
+
+def api(url, tok, body=None):
+    headers = {'Authorization': f'Bearer {tok}', 'Content-Type': 'application/json'}
+    req = urllib.request.Request(url, body, headers)
+    with urllib.request.urlopen(req) as fid:
+        return json.load(fid)
+
+
+def gql(tok, query, variables):
+    res = api(GRAPHQL, tok, json.dumps(dict(query=query, variables=variables)).encode())
+    if res.get('errors'):
+        sys.exit(json.dumps(res['errors'], indent=2))
+    return res['data']
+
+
+QUERY = """
+query($tag:string!, $start:Time!, $end:Time!, $script:string!) {
+  viewer { accounts(filter:{accountTag:$tag}) {
+    workersInvocationsAdaptive(limit:1000, orderBy:[date_ASC], filter:{
+        datetime_geq:$start, datetime_leq:$end, scriptName:$script}) {
+      dimensions { date }
+      sum { requests errors subrequests }
+      quantiles { cpuTimeP50 cpuTimeP99 wallTimeP50 }
+    }
+  }}
+}"""
+
+# Invocation outcomes: anything other than `success` is worth knowing about, and
+# `exceededCpu` is the one the free plan's 10 ms limit actually produces.
+STATUS_QUERY = """
+query($tag:string!, $start:Time!, $end:Time!, $script:string!) {
+  viewer { accounts(filter:{accountTag:$tag}) {
+    workersInvocationsAdaptive(limit:100, filter:{
+        datetime_geq:$start, datetime_leq:$end, scriptName:$script}) {
+      dimensions { status }
+      sum { requests }
+    }
+  }}
+}"""
+
+
+def main():
+    days = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+    tok = token()
+
+    wrangler = Path(__file__).resolve().parent.parent / 'wrangler.toml'
+    script = re.search(r'^name\s*=\s*"([^"]+)"', wrangler.read_text(), re.M).group(1)
+    account = api('https://api.cloudflare.com/client/v4/accounts', tok)['result'][0]['id']
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    fmt = '%Y-%m-%dT%H:%M:%SZ'
+    rows = gql(tok, QUERY, dict(
+        tag=account, script=script,
+        start=start.strftime(fmt), end=end.strftime(fmt),
+    ))['viewer']['accounts'][0]['workersInvocationsAdaptive']
+    if not rows:
+        sys.exit(f'no requests to {script} in the last {days} days')
+
+    print(f'{script}  (last {days} days, free tier = {DAILY_FREE_REQUESTS:,} req/day)\n')
+    print(f'{"date":<12}{"reqs":>7}{"errs":>6}{"subreq":>8}{"cpu p50":>9}{"cpu p99":>9}'
+          f'{"% of quota":>12}')
+    print('-' * 63)
+    for row in rows:
+        n = row['sum']['requests']
+        q = row['quantiles']
+        print(f'{row["dimensions"]["date"]:<12}{n:>7}{row["sum"]["errors"]:>6}'
+              f'{row["sum"]["subrequests"]:>8}{q["cpuTimeP50"]:>7}us{q["cpuTimeP99"]:>7}us'
+              f'{100 * n / DAILY_FREE_REQUESTS:>11.3f}%')
+
+    total = sum(row['sum']['requests'] for row in rows)
+    errors = sum(row['sum']['errors'] for row in rows)
+    peak = max(row['sum']['requests'] for row in rows)
+    mean = total / len(rows)
+    print('-' * 63)
+    print(f'{len(rows)} active days | {total:,} requests | {errors} errors')
+    print(f'mean {mean:,.0f}/day ({100 * mean / DAILY_FREE_REQUESTS:.3f}% of quota), '
+          f'peak {peak:,} ({100 * peak / DAILY_FREE_REQUESTS:.3f}%)')
+    print(f'room to grow {DAILY_FREE_REQUESTS / peak:,.0f}x before the peak day hits the cap')
+
+    statuses = gql(tok, STATUS_QUERY, dict(
+        tag=account, script=script,
+        start=start.strftime(fmt), end=end.strftime(fmt),
+    ))['viewer']['accounts'][0]['workersInvocationsAdaptive']
+    bad = {row['dimensions']['status']: row['sum']['requests']
+           for row in statuses if row['dimensions']['status'] != 'success'}
+    print('invocation outcomes: ' + (', '.join(f'{k}={v}' for k, v in bad.items())
+                                     if bad else 'all success'))
+
+    # Requests are not the binding constraint at this scale; CPU per invocation is.
+    worst = max(row['quantiles']['cpuTimeP99'] for row in rows)
+    if worst > FREE_CPU_LIMIT_US:
+        print(f'NOTE: peak cpu p99 {worst / 1000:.1f}ms exceeds the free '
+              f'{FREE_CPU_LIMIT_US / 1000:.0f}ms/invocation limit; Cloudflare tolerates '
+              f'infrequent overruns but kills consistent ones (error 1102)')
+
+
+main()

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -365,3 +365,21 @@ test('the documented spelling wins when a repo has several', async () => {
   assert.ok(seen.some((r) => r.url.includes(`/contents/${CONFIG_DIR}/${CANONICAL_CONFIG}`)))
   assert.ok(!seen.some((r) => r.url.includes('circle_artifacts.yml')))
 })
+
+// The Worker gets 10 ms of CPU per request (see CLAUDE.md) and the artifacts
+// listing is ~1 MB for a large docs build, so a debug message nobody reads must
+// cost nothing. `toJSON` is the tripwire: JSON.stringify() cannot serialize the
+// payload without calling it. Injected through a bare response object because a
+// real Response would round-trip through text and drop the hook.
+test('a delivery never serializes the artifacts payload', async () => {
+  const artifacts = {items: [ARTIFACT], serialized: 0}
+  artifacts.toJSON = () => { artifacts.serialized++; return {items: [ARTIFACT]} }
+  const base = backend()
+  const fetchFn = async (url, options) => url.includes('/artifacts')
+    ? {ok: true, status: 200, json: async () => artifacts}
+    : base.fetchFn(url, options)
+
+  const response = await handle(webhook(PAYLOAD), ENV, {fetchFn})
+  assert.equal(response.status, 200, 'the status still posts')
+  assert.equal(artifacts.serialized, 0, 'serializing it costs ~2x parsing it')
+})


### PR DESCRIPTION
Two related things, both prompted by looking at what the deployed Worker actually costs.

## `tools/cf-usage.py`

There is no usage command in `wrangler`, and the dashboard's Metrics tab shows performance telemetry but **never plots you against the free-tier limits**. So this reports both:

```
$ tools/cf-usage.py 30
circleci-artifacts-redirector-app  (last 30 days, free tier = 100,000 req/day)

date           reqs  errs  subreq  cpu p50  cpu p99  % of quota
---------------------------------------------------------------
2026-07-28      449     0     339   1178us   9359us      0.449%
2026-07-29      106     0     136   2131us  11249us      0.106%
---------------------------------------------------------------
2 active days | 555 requests | 0 errors
mean 278/day (0.278% of quota), peak 449 (0.449%)
room to grow 223x before the peak day hits the cap
invocation outcomes: all success
NOTE: peak cpu p99 11.2ms exceeds the free 10ms/invocation limit; ...
```

It authenticates with the OAuth token `wrangler login` already stored — the `account:read` scope turns out to be enough for the GraphQL Analytics API, so there is no second token to create or rotate. Python stdlib only; account ID comes from the API and the Worker name from `wrangler.toml`, so nothing is hardcoded.

## The CPU fix

Running it made the actual constraint obvious, and it is **not** the request cap. Traffic is 0.45% of 100,000/day with ~200x headroom. But the free plan also allows only **10 ms of CPU per invocation**, and the p99 was already 9–15 ms. Cloudflare tolerates infrequent overruns and terminates a Worker that consistently exceeds it (error 1102).

The largest single cost was a debug message nobody reads:

```js
log(`Artifacts JSON: ${JSON.stringify(artifacts)}`)
```

The Worker's `log` is `() => {}`, but a no-op logger still evaluates its argument. And that payload is not small — a docs build lists thousands of files:

| Project | Artifacts | JSON |
|---|---|---|
| scikit-learn | 3,904 | 982 KB |
| MNE-Python | 3,290 | 755 KB |

Measured on the real scikit-learn payload:

| Operation | Cost |
|---|---|
| `JSON.parse` (unavoidable, `res.json()`) | ~1.5 ms |
| **`JSON.stringify` (the no-op log arg)** | **~2.8 ms** |
| RSA import + JWT sign (token cache miss only) | ~1.0 ms |
| HMAC import + signature verify | ~0.08 ms |

So the discarded log line cost about twice the unavoidable parse, and more than all the crypto combined. It also scales with docs size, which is exactly backwards for the repos we want to onboard next.

The fix passes a **thunk** for expensive debug messages and lets each front end decide: the Worker never builds it, and the action builds it only when `core.isDebug()` is true. Debug output is unchanged when it is actually switched on.

I looked at caching the imported HMAC and RSA keys too, but that is ~22 µs/request and ~70 µs/mint — not worth the code.

## Testing

Two guards, one per front end. The fake artifacts payload carries a `toJSON` hook that counts serializations and the tests assert it is never called: `JSON.stringify` cannot serialize the payload without calling it, which is a deterministic tripwire where asserting on elapsed milliseconds would be flaky.

Mutation-tested per `CLAUDE.md` — reverting the one-line `src/core.js` change alone fails exactly those two tests and nothing else:

```
not ok 24 - the artifacts payload is not serialized when the log discards it
not ok 56 - a delivery never serializes the artifacts payload
```

56 tests, coverage still 100% line/branch/function.

`CLAUDE.md` gains a "CPU is the limit that binds, not requests" section with the measurements, so the next person does not undo the thunk to "simplify" it.

Needs a `wrangler deploy` after merge to take effect on the running Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
