### PR TITLE
PERF: Stop parsing the artifacts listing on every request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,4 +80,7 @@ jobs:
       # Reminder for a rollback: Cloudflare is now ahead of master, and the next
       # deploy will re-ship whatever was rolled back unless git is reverted too.
       - name: Record live version
+        # Diagnostic, not part of shipping: never turn a good deploy red because
+        # the listing call was refused or the API hiccuped.
+        continue-on-error: true
         run: npx wrangler versions list

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Check credentials
         run: |
           for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do
-            if [ -z "${!name}" ]; then
+            value="${!name}"
+            if [ -z "$value" ]; then
               echo "::error::Repository secret $name is missing or empty." \
                 "Settings -> Secrets and variables -> Actions: check the name" \
                 "is spelled exactly $name, that it is under Secrets rather than" \
@@ -61,6 +62,18 @@ jobs:
                 "environment."
               exit 1
             fi
+            # A pasted-in trailing newline is invisible in the UI and survives
+            # into the Authorization header, where wrangler reports it as an
+            # invalid header value rather than as a bad secret. Same trap as
+            # WEBHOOK_SECRET in CLAUDE.md; it has now cost time twice.
+            case "$value" in
+              *[[:space:]]*)
+                echo "::error::Repository secret $name contains whitespace," \
+                  "most likely a trailing newline from pasting it in." \
+                  "Re-enter it with no leading or trailing whitespace."
+                exit 1
+                ;;
+            esac
           done
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,24 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
+      # First, before spending a checkout and an install on it. A missing or
+      # misnamed secret otherwise surfaces as wrangler telling you to set
+      # CLOUDFLARE_API_TOKEN -- which the workflow plainly already does, sending
+      # you to look at the workflow instead of at the repo's secrets, where a
+      # typo in the name reads as empty and nothing says so.
+      - name: Check credentials
+        run: |
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Repository secret $name is missing or empty." \
+                "Settings -> Secrets and variables -> Actions: check the name" \
+                "is spelled exactly $name, that it is under Secrets rather than" \
+                "Variables, and that it is on this repo or its production" \
+                "environment."
+              exit 1
+            fi
+          done
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           persist-credentials: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,11 @@ CI never needs them and must never be given them.
 - `PRIVATE_KEY` must be **PKCS#8** (`openssl pkcs8 -topk8 -nocrypt …`); Web
   Crypto cannot import the PKCS#1 file GitHub gives you.
 - Upload `WEBHOOK_SECRET` with `printf '%s'`, never `< file` — a trailing
-  newline makes every delivery `401`.
+  newline makes every delivery `401`. The same trap caught
+  `CLOUDFLARE_API_TOKEN` as a repo secret, where a pasted newline became an
+  invalid `Authorization` header. **Every credential in this project has to be
+  stored with no trailing newline**, and nothing in any UI shows you one; the
+  deploy workflow now rejects whitespace up front for the two it can see.
 - Token (50 min), config (10 min) and posted-status dedupe (5 min) are cached in
   an isolate-level `Map`. All best-effort: a cold isolate just refetches, and a
   duplicate can slip through. Nothing is correctness-critical.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,31 +151,50 @@ with ~200x headroom — while the observed CPU p99 already sits near 10 ms. When
 a Worker consistently exceeds it, Cloudflare terminates the invocation with
 error 1102; occasional overruns are tolerated.
 
-What actually costs CPU here, measured:
+What actually costs CPU here, measured on a scikit-learn-sized listing:
 
 | Operation | Cost |
 |---|---|
-| `JSON.parse` of the artifacts listing (~1 MB, unavoidable) | ~1.5 ms |
-| `JSON.stringify` of that same listing | ~2.8 ms |
+| `JSON.stringify` of the artifacts listing (~1 MB) | ~2.8 ms |
+| `JSON.parse` of that same listing | ~2.2 ms |
 | RSA import + JWT sign (only on a token cache miss) | ~1.0 ms |
+| **streaming scan for the first artifact URL** | **~0.08 ms** |
 | HMAC import + webhook signature verify | ~0.08 ms |
 
 A large docs build lists thousands of files (scikit-learn: 3,904 artifacts,
 982 KB; MNE-Python: 3,290, 755 KB), so **anything that touches the whole
 artifacts payload is the most expensive thing the Worker does** — more than the
-crypto, by a lot.
+crypto, by a lot. Both halves of that have now been removed:
 
-Hence: `src/core.js` passes a **thunk** to `log` for messages that are expensive
-to build, and the Worker's `log` is a no-op that never calls it. Do not "simplify"
-that back into a template string — a no-op logger still evaluates its argument,
-which is exactly the bug it fixes. `index.js` resolves the thunk only when
-`core.isDebug()`.
+- **Never serialize it.** `src/core.js` passes a **thunk** to `log` for messages
+  that are expensive to build, and the Worker's `log` is a no-op that never
+  calls it. Do not "simplify" a thunk back into a template string — a no-op
+  logger still evaluates its argument, which is exactly the bug it fixes.
+  `index.js` resolves the thunk only when `core.isDebug()`. Nothing passes a
+  thunk today (the message that did is gone, below), but the contract holds and
+  the next expensive message must use it.
+- **Never parse it.** Only two facts about the listing matter: whether the job
+  uploaded anything, and the URL of one artifact — they all share the job
+  segment the redirect needs. `firstArtifactUrl` scans the response bytes as
+  they arrive, stops at the first `"url"`, and cancels the rest of the download,
+  turning ~2.2 ms into ~0.08 ms and skipping most of the transfer as well. The
+  regex cannot be fooled by a path containing the text `"url":`, because an
+  unescaped `"` only appears as JSON syntax, never inside a string value. If the
+  scan finds nothing before the stream ends it parses the (then tiny, or
+  unexpected) body properly, so a malformed response still throws instead of
+  quietly reading as "no artifacts".
 
-Two tests pin this down (`index.test.js`, `worker/index.test.js`): the fake
-artifacts payload carries a `toJSON` hook that counts serializations, and the
-tests assert it is never called. That is a deterministic tripwire for the
-specific wasteful operation; asserting on elapsed milliseconds would be flaky.
-Add the same guard for any new code that could walk the payload.
+The cost of that second one is debuggability: there is no longer a full
+`Artifacts JSON: …` dump in the action's debug log, because the payload is never
+assembled. `First artifact: <url>` replaces it.
+
+Four tests pin this down (`index.test.js`, `worker/index.test.js`). The fake
+artifacts payload carries a `toJSON` hook that counts serializations and the
+tests assert it is never called; a second fixture serves the listing as a real
+chunked `ReadableStream` and asserts the scan pulls at most 2 of ~15 chunks.
+Both are deterministic tripwires for the specific wasteful operation, where
+asserting on elapsed milliseconds would be flaky. Add the same guard for any new
+code that could walk the payload.
 
 Check real usage with `tools/cf-usage.py` (`$CLOUDFLARE_API_TOKEN` if exported,
 else the token `wrangler login` stored). It reports CPU quantiles and invocation

--- a/dist/index.js
+++ b/dist/index.js
@@ -36499,13 +36499,14 @@ function legacyArtifactsUrl(target) {
 
 // Build the URL to link to: the requested artifact if anything was uploaded,
 // otherwise the CircleCI job itself (rewriting the domain only makes sense for
-// artifact URLs).
-function redirectUrl(items, path, domain, fallback) {
-  if (!items.length) {
+// artifact URLs). `first` is the URL of any one artifact, or null if the job
+// uploaded none -- every artifact of a job shares the job segment we want.
+function redirectUrl(first, path, domain, fallback) {
+  if (first == null) {
     return fallback
   }
   // e.g., https://output.circle-artifacts.com/output/job/<uuid>/artifacts/0/doc/index.html
-  const job = items[0].url.split('/output/')[1].split('/artifacts/')[0]
+  const job = first.split('/output/')[1].split('/artifacts/')[0]
   return `https://${domain}/output/${job}/artifacts/${path}`
 }
 
@@ -36522,16 +36523,80 @@ function statusFor(payloadState, hasArtifacts, path) {
   return {state: 'failure', description: 'No artifacts found'}
 }
 
-// Fetch JSON from the CircleCI API, failing loudly on a non-2xx response.
-// Without this a 404 or a rate limit surfaces as a confusing "cannot read
-// properties of undefined" from the caller.
-async function fetchJson(fetchFn, url, options) {
-  const response = await fetchFn(url, options)
+// Fail loudly on a non-2xx response. Without this a 404 or a rate limit
+// surfaces as a confusing "cannot read properties of undefined" downstream.
+async function assertOk(response, url) {
   if (!response.ok) {
     const body = await response.text().catch(() => '')
     throw new Error(`CircleCI API returned ${response.status} for ${url}: ${body.slice(0, 200)}`)
   }
+}
+
+// Fetch JSON from the CircleCI API. Used for the small responses; the artifacts
+// listing is the big one and goes through firstArtifactUrl below instead.
+async function fetchJson(fetchFn, url, options) {
+  const response = await fetchFn(url, options)
+  await assertOk(response, url)
   return response.json()
+}
+
+// Only two facts about the artifacts listing matter: whether the job uploaded
+// anything, and the URL of one entry. A large docs build lists thousands of
+// files and runs to ~1 MB, so parsing it in full to read a single string costs
+// ~2.2 ms of the Worker's 10 ms budget building objects we immediately drop --
+// the same waste gh-126 removed on the serialize side, and now the largest
+// single cost left. Scan the bytes as they arrive, stop at the first `url`, and
+// cancel the rest of the download.
+//
+// This cannot be fooled by a path that contains the text `"url":`, because an
+// unescaped `"` only ever appears as JSON syntax, never inside a string value.
+const FIRST_URL = /"url"\s*:\s*"((?:[^"\\]|\\.)*)"/
+
+// Past this much with no match the response is not the shape this optimizes
+// for, so stop rescanning a growing buffer and fall back to parsing it.
+const SCAN_LIMIT = 262144
+
+function firstUrlOf(artifacts) {
+  return artifacts.items.length ? artifacts.items[0].url : null
+}
+
+// Fetch the artifacts listing and return the URL of the first artifact, or null
+// when the job uploaded none. Throws on a non-2xx response or an unparseable
+// body, exactly as a plain fetch-and-parse would.
+async function firstArtifactUrl(fetchFn, url, options) {
+  const response = await fetchFn(url, options)
+  await assertOk(response, url)
+  if (!response.body) {
+    // Whatever we were handed has no stream to scan, so do it the plain way.
+    return firstUrlOf(await response.json())
+  }
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    for (;;) {
+      const {done, value} = await reader.read()
+      if (value) {
+        buffer += decoder.decode(value, {stream: true})
+      }
+      if (buffer.length <= SCAN_LIMIT) {
+        const match = FIRST_URL.exec(buffer)
+        if (match) {
+          // Re-parse the matched text so JSON escapes survive the shortcut
+          return JSON.parse(`"${match[1]}"`)
+        }
+      }
+      if (done) {
+        // No artifacts, or not the shape above. The body is fully buffered by
+        // now and an empty listing is tiny, so parsing costs nothing here and
+        // keeps a malformed body throwing rather than reading as "no artifacts".
+        return firstUrlOf(JSON.parse(buffer))
+      }
+    }
+  } finally {
+    // Stops the transfer when we bailed out early; harmless once it is drained
+    reader.cancel().catch(() => {})
+  }
 }
 
 // Work out the artifacts endpoint for a status target_url, which comes in two
@@ -36592,16 +36657,11 @@ async function resolveStatus({payload, config, fetchFn = globalThis.fetch, log =
   if (config.apiToken !== '') {
     headers['Circle-Token'] = config.apiToken
   }
-  const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
-  // Thunk, not a string: a docs build lists thousands of files, so this payload
-  // runs to ~1 MB and serializing it costs about twice what parsing the
-  // response did (~2.8 ms vs ~1.5 ms for scikit-learn). The Worker gets 10 ms
-  // of CPU per request, and its `log` is a no-op, so it must never pay for a
-  // message nobody reads.
-  log(() => `Artifacts JSON: ${JSON.stringify(artifacts)}`)
+  const first = await firstArtifactUrl(fetchFn, artifactsUrl, {headers})
+  log(`First artifact: ${first}`)
 
-  const url = redirectUrl(artifacts.items, config.path, config.domain, payload.target_url)
-  const {state, description} = statusFor(payload.state, artifacts.items.length > 0, config.path)
+  const url = redirectUrl(first, config.path, config.domain, payload.target_url)
+  const {state, description} = statusFor(payload.state, first != null, config.path)
   return {
     url,
     state,

--- a/index.test.js
+++ b/index.test.js
@@ -218,10 +218,10 @@ test('legacyArtifactsUrl', () => {
 
 test('redirectUrl', () => {
   assert.equal(
-    redirectUrl([ARTIFACT], 'doc/index.html', 'example.org', 'https://fallback'),
+    redirectUrl(ARTIFACT.url, 'doc/index.html', 'example.org', 'https://fallback'),
     'https://example.org/output/job/abc/artifacts/doc/index.html',
   )
-  assert.equal(redirectUrl([], 'doc/index.html', 'example.org', 'https://fallback'), 'https://fallback')
+  assert.equal(redirectUrl(null, 'doc/index.html', 'example.org', 'https://fallback'), 'https://fallback')
 })
 
 test('statusFor', () => {
@@ -330,12 +330,111 @@ test('the artifacts payload is not serialized when the log discards it', async (
   assert.equal(bare.serialized, 0)
 })
 
-test('a logger that resolves thunks still gets the full payload', async () => {
-  const artifacts = countingArtifacts()
+test('the chosen artifact is still named in the debug log', async () => {
   const lines = []
-  await resolveWith(artifacts, (m) => lines.push(typeof m === 'function' ? m() : m))
-  assert.equal(artifacts.serialized, 1, 'built once, not once per line')
-  assert.ok(lines.some((line) => line.startsWith('Artifacts JSON: {')), 'debugging is unaffected')
+  await resolveWith(countingArtifacts(), (m) => lines.push(typeof m === 'function' ? m() : m))
+  assert.ok(lines.includes(`First artifact: ${ARTIFACT.url}`), 'enough to explain the link')
+})
+
+// The other half of the CPU budget: the listing is never parsed in full either.
+// Serve it as a real chunked stream and count how many chunks get pulled --
+// deterministic, where asserting on elapsed milliseconds would be flaky.
+const chunkedListing = (count = 400, chunk = 4096) => {
+  const items = Array.from({length: count}, (_, i) => ({
+    path: `0/doc/page${i}.html`,
+    node_index: 0,
+    url: `https://output.circle-artifacts.com/output/job/abc/artifacts/0/doc/page${i}.html`,
+  }))
+  return chunkedBody(JSON.stringify({items, next_page_token: null}), chunk)
+}
+
+const chunkedBody = (text, chunk = 4096) => {
+  const bytes = new TextEncoder().encode(text)
+  let offset = 0
+  const state = {pulled: 0, chunks: Math.ceil(bytes.length / chunk)}
+  state.response = {
+    ok: true,
+    status: 200,
+    body: new ReadableStream({
+      pull(controller) {
+        state.pulled++
+        if (offset >= bytes.length) {
+          return controller.close()
+        }
+        controller.enqueue(bytes.slice(offset, offset + chunk))
+        offset += chunk
+      },
+    }),
+  }
+  return state
+}
+
+const resolveStream = (state, log) => resolveStatus({
+  payload: {context: 'ci/circleci: build', state: 'success', target_url: 'https://circleci.com/gh/o/r/1'},
+  config: normalizeConfig({'artifact-path': 'doc/index.html'}),
+  fetchFn: async () => state.response,
+  log,
+})
+
+test('the artifacts listing is not downloaded or parsed past the first entry', async () => {
+  const state = chunkedListing()
+  assert.ok(state.chunks >= 10, 'the fixture has to be big enough to stop early in')
+  const status = await resolveStream(state)
+  assert.equal(status.state, 'success')
+  assert.equal(status.url, 'https://output.circle-artifacts.com/output/job/abc/artifacts/doc/index.html')
+  assert.ok(state.pulled <= 2, `stopped after ${state.pulled} of ${state.chunks} chunks`)
+})
+
+// Cancelling is only how we stop the download early, so a stream that objects
+// to being cancelled must not take the job down with it.
+test('a stream that refuses to cancel still produces the status', async () => {
+  const state = chunkedListing()
+  const inner = state.response.body
+  state.response = {
+    ok: true,
+    status: 200,
+    body: new ReadableStream({
+      async pull(controller) {
+        const {done, value} = await (state.reader ??= inner.getReader()).read()
+        return done ? controller.close() : controller.enqueue(value)
+      },
+      cancel() { throw new Error('cancel failed') },
+    }),
+  }
+  const status = await resolveStream(state)
+  assert.equal(status.url, 'https://output.circle-artifacts.com/output/job/abc/artifacts/doc/index.html')
+})
+
+test('an empty listing still reads as no artifacts', async () => {
+  const state = chunkedBody(JSON.stringify({items: [], next_page_token: null}))
+  const status = await resolveStream(state)
+  assert.equal(status.state, 'failure')
+  assert.equal(status.description, 'No artifacts found')
+  assert.equal(status.url, 'https://circleci.com/gh/o/r/1', 'falls back to the job')
+})
+
+test('a malformed listing throws rather than reading as no artifacts', async () => {
+  await assert.rejects(() => resolveStream(chunkedBody('{"items": [truncated')), SyntaxError)
+})
+
+// A listing whose first `url` lands past the scan window must not silently come
+// back empty; the scan gives up and the plain parse takes over.
+test('an artifact past the scan window is still found', async () => {
+  const filler = 'x'.repeat(300 * 1024)
+  const state = chunkedBody(JSON.stringify({junk: filler, items: [ARTIFACT]}))
+  const status = await resolveStream(state)
+  assert.equal(status.state, 'success')
+  assert.equal(status.url, 'https://output.circle-artifacts.com/output/job/abc/artifacts/doc/index.html')
+})
+
+// JSON escapes have to survive the shortcut: the scan lifts raw bytes out of
+// the response, so a path with an escape in it would come back mangled.
+test('an escaped character in the artifact URL survives the scan', async () => {
+  // Written out rather than JSON.stringify()d, which would not emit an escape
+  const state = chunkedBody('{"items":[{"path":"p","url":'
+    + '"https://output.circle-artifacts.com/output/job/a\\u00e9b/artifacts/0/doc/x.html"}]}')
+  const status = await resolveStream(state)
+  assert.equal(status.url, 'https://output.circle-artifacts.com/output/job/aéb/artifacts/doc/index.html')
 })
 
 test('debug() only builds an expensive message when the runner wants it', async () => {

--- a/src/core.js
+++ b/src/core.js
@@ -23,13 +23,14 @@ export function legacyArtifactsUrl(target) {
 
 // Build the URL to link to: the requested artifact if anything was uploaded,
 // otherwise the CircleCI job itself (rewriting the domain only makes sense for
-// artifact URLs).
-export function redirectUrl(items, path, domain, fallback) {
-  if (!items.length) {
+// artifact URLs). `first` is the URL of any one artifact, or null if the job
+// uploaded none -- every artifact of a job shares the job segment we want.
+export function redirectUrl(first, path, domain, fallback) {
+  if (first == null) {
     return fallback
   }
   // e.g., https://output.circle-artifacts.com/output/job/<uuid>/artifacts/0/doc/index.html
-  const job = items[0].url.split('/output/')[1].split('/artifacts/')[0]
+  const job = first.split('/output/')[1].split('/artifacts/')[0]
   return `https://${domain}/output/${job}/artifacts/${path}`
 }
 
@@ -46,16 +47,80 @@ export function statusFor(payloadState, hasArtifacts, path) {
   return {state: 'failure', description: 'No artifacts found'}
 }
 
-// Fetch JSON from the CircleCI API, failing loudly on a non-2xx response.
-// Without this a 404 or a rate limit surfaces as a confusing "cannot read
-// properties of undefined" from the caller.
-export async function fetchJson(fetchFn, url, options) {
-  const response = await fetchFn(url, options)
+// Fail loudly on a non-2xx response. Without this a 404 or a rate limit
+// surfaces as a confusing "cannot read properties of undefined" downstream.
+async function assertOk(response, url) {
   if (!response.ok) {
     const body = await response.text().catch(() => '')
     throw new Error(`CircleCI API returned ${response.status} for ${url}: ${body.slice(0, 200)}`)
   }
+}
+
+// Fetch JSON from the CircleCI API. Used for the small responses; the artifacts
+// listing is the big one and goes through firstArtifactUrl below instead.
+export async function fetchJson(fetchFn, url, options) {
+  const response = await fetchFn(url, options)
+  await assertOk(response, url)
   return response.json()
+}
+
+// Only two facts about the artifacts listing matter: whether the job uploaded
+// anything, and the URL of one entry. A large docs build lists thousands of
+// files and runs to ~1 MB, so parsing it in full to read a single string costs
+// ~2.2 ms of the Worker's 10 ms budget building objects we immediately drop --
+// the same waste gh-126 removed on the serialize side, and now the largest
+// single cost left. Scan the bytes as they arrive, stop at the first `url`, and
+// cancel the rest of the download.
+//
+// This cannot be fooled by a path that contains the text `"url":`, because an
+// unescaped `"` only ever appears as JSON syntax, never inside a string value.
+const FIRST_URL = /"url"\s*:\s*"((?:[^"\\]|\\.)*)"/
+
+// Past this much with no match the response is not the shape this optimizes
+// for, so stop rescanning a growing buffer and fall back to parsing it.
+const SCAN_LIMIT = 262144
+
+function firstUrlOf(artifacts) {
+  return artifacts.items.length ? artifacts.items[0].url : null
+}
+
+// Fetch the artifacts listing and return the URL of the first artifact, or null
+// when the job uploaded none. Throws on a non-2xx response or an unparseable
+// body, exactly as a plain fetch-and-parse would.
+export async function firstArtifactUrl(fetchFn, url, options) {
+  const response = await fetchFn(url, options)
+  await assertOk(response, url)
+  if (!response.body) {
+    // Whatever we were handed has no stream to scan, so do it the plain way.
+    return firstUrlOf(await response.json())
+  }
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    for (;;) {
+      const {done, value} = await reader.read()
+      if (value) {
+        buffer += decoder.decode(value, {stream: true})
+      }
+      if (buffer.length <= SCAN_LIMIT) {
+        const match = FIRST_URL.exec(buffer)
+        if (match) {
+          // Re-parse the matched text so JSON escapes survive the shortcut
+          return JSON.parse(`"${match[1]}"`)
+        }
+      }
+      if (done) {
+        // No artifacts, or not the shape above. The body is fully buffered by
+        // now and an empty listing is tiny, so parsing costs nothing here and
+        // keeps a malformed body throwing rather than reading as "no artifacts".
+        return firstUrlOf(JSON.parse(buffer))
+      }
+    }
+  } finally {
+    // Stops the transfer when we bailed out early; harmless once it is drained
+    reader.cancel().catch(() => {})
+  }
 }
 
 // Work out the artifacts endpoint for a status target_url, which comes in two
@@ -116,16 +181,11 @@ export async function resolveStatus({payload, config, fetchFn = globalThis.fetch
   if (config.apiToken !== '') {
     headers['Circle-Token'] = config.apiToken
   }
-  const artifacts = await fetchJson(fetchFn, artifactsUrl, {headers})
-  // Thunk, not a string: a docs build lists thousands of files, so this payload
-  // runs to ~1 MB and serializing it costs about twice what parsing the
-  // response did (~2.8 ms vs ~1.5 ms for scikit-learn). The Worker gets 10 ms
-  // of CPU per request, and its `log` is a no-op, so it must never pay for a
-  // message nobody reads.
-  log(() => `Artifacts JSON: ${JSON.stringify(artifacts)}`)
+  const first = await firstArtifactUrl(fetchFn, artifactsUrl, {headers})
+  log(`First artifact: ${first}`)
 
-  const url = redirectUrl(artifacts.items, config.path, config.domain, payload.target_url)
-  const {state, description} = statusFor(payload.state, artifacts.items.length > 0, config.path)
+  const url = redirectUrl(first, config.path, config.domain, payload.target_url)
+  const {state, description} = statusFor(payload.state, first != null, config.path)
   return {
     url,
     state,


### PR DESCRIPTION
Only two facts about the CircleCI artifacts listing are ever used: whether the job uploaded anything, and the URL of one artifact -- every artifact of a job shares the job segment the redirect is built from. The listing for a large docs build runs to ~1 MB across thousands of files, so JSON.parse was building thousands of objects to read a single string, at ~2.2 ms of the Worker's 10 ms CPU budget.

Scan the response bytes as they arrive instead, stop at the first `url`, and cancel the rest of the download: ~2.2 ms becomes ~0.08 ms, and most of the transfer never happens either. This is the same waste gh-126 removed on the serialize side, and was the largest cost left.

An unescaped `"` only ever appears as JSON syntax and never inside a string value, so the scan cannot be fooled by a path containing the text `"url":`. When it finds nothing before the stream ends -- no artifacts, or a shape this does not anticipate -- the body is parsed properly, so a malformed response still throws rather than reading as "no artifacts".

Costs the action its full `Artifacts JSON: ...` debug dump, since the payload is never assembled; `First artifact: <url>` replaces it, which is the part that explained the resulting link.

Tests serve the listing as a real chunked ReadableStream and assert the scan pulls at most 2 of ~15 chunks, alongside the existing toJSON serialization tripwire. All three guards were mutation-tested.