### PR TITLE
MAINT: Supply-chain guards, dist/ freshness check, weekly Worker usage check

### DIFF
--- a/.github/actions/report-issue/action.yml
+++ b/.github/actions/report-issue/action.yml
@@ -1,0 +1,33 @@
+# Shared by the automated checks (check-dist in tests.yaml, usage.yml) whose
+# failures nobody would otherwise see: a red X on a master push or a cron run
+# notifies no one. The title doubles as the dedupe key, so a recurring failure
+# accumulates comments on one open issue instead of spamming new ones.
+#
+# Composite, so it needs a checkout first and the calling job needs
+# `issues: write`.
+name: Report an issue
+description: Open an issue with this title, or comment on the open one that has it
+inputs:
+  title:
+    description: Exact issue title, also the dedupe key
+    required: true
+  body:
+    description: Markdown body for the new issue or the follow-up comment
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+      run: |
+        existing=$(gh issue list --state open --search "\"$TITLE\" in:title" \
+          --json number --jq '.[0].number')
+        if [ -z "$existing" ]; then
+          gh issue create --title "$TITLE" --body "$BODY"
+        else
+          gh issue comment "$existing" --body "$BODY"
+        fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # npm code gets bundled into dist/ and shipped to every consumer of the
+    # action, so never pick up a release until it has survived two weeks in
+    # the wild -- most compromised packages are yanked within days.
+    cooldown:
+      default-days: 14
     groups:
       npm:
         patterns:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,6 +20,10 @@ jobs:
     name: Rebuild dist
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          # autofix.ci applies the diff through its own App, so the workflow
+          # itself never needs a writable token on disk
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,11 +8,24 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Names can be found with gh api /repos/mne-tools/mne-python/pulls/12998 -q .user.login for example
     if: (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') && github.repository == 'scientific-python/circleci-artifacts-redirector-action'
     steps:
-      - name: Enable auto-merge for bot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
+      # dist/ is the code every consumer of the action actually runs, so a bot
+      # PR that changes it (a dependency bump that autofix.ci re-bundles) must
+      # get human eyes before it merges. This runs on `synchronize` too, so
+      # when autofix.ci pushes a rebuilt dist/ to a PR whose auto-merge was
+      # already enabled, the disable below undoes it before the merge can fire.
+      - name: Enable auto-merge for bot PRs, unless dist/ changed
+        run: |
+          files=$(gh pr diff --name-only "$PR_URL")
+          if printf '%s\n' "$files" | grep -q '^dist/'; then
+            # Errors if auto-merge was never enabled; that outcome is fine
+            gh pr merge --disable-auto "$PR_URL" || true
+          else
+            gh pr merge --auto --squash "$PR_URL"
+          fi
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,3 +32,42 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info
           flags: github-actions
+
+  # dist/ is what action consumers actually run. autofix.ci rebuilds it on
+  # PRs, but nothing guards a direct push (or an autofix outage), and a stale
+  # bundle on master ships silently to everyone on @master. On PRs a red check
+  # is enough; on master pushes nobody is watching, so open an issue.
+  check-dist:
+    name: dist is up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - run: npm run package
+      - run: git diff --exit-code -- dist/
+      - name: Open an issue so the stale bundle does not ship unnoticed
+        if: failure() && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title='dist/ on master is stale'
+          existing=$(gh issue list --state open --search "\"$title\" in:title" \
+            --json number --jq '.[0].number')
+          body="\`dist/index.js\` on master no longer matches what \`npm run
+          package\` builds from \`index.js\` + \`src/\`, so consumers of the
+          action are running stale code. Rebuild and commit it: $RUN_URL"
+          if [ -z "$existing" ]; then
+            gh issue create --title "$title" --body "$body"
+          else
+            gh issue comment "$existing" --body "Still stale: $RUN_URL"
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,18 +56,11 @@ jobs:
       - run: git diff --exit-code -- dist/
       - name: Open an issue so the stale bundle does not ship unnoticed
         if: failure() && github.event_name == 'push'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          title='dist/ on master is stale'
-          existing=$(gh issue list --state open --search "\"$title\" in:title" \
-            --json number --jq '.[0].number')
-          body="\`dist/index.js\` on master no longer matches what \`npm run
-          package\` builds from \`index.js\` + \`src/\`, so consumers of the
-          action are running stale code. Rebuild and commit it: $RUN_URL"
-          if [ -z "$existing" ]; then
-            gh issue create --title "$title" --body "$body"
-          else
-            gh issue comment "$existing" --body "Still stale: $RUN_URL"
-          fi
+        uses: ./.github/actions/report-issue
+        with:
+          title: dist/ on master is stale
+          body: >-
+            `dist/index.js` on master no longer matches what `npm run package`
+            builds from `index.js` + `src/`, so consumers of the action are
+            running stale code. Rebuild and commit it:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -4,12 +4,11 @@
 # p99 already sits near it (see CLAUDE.md). A failed check opens an issue --
 # a red X on a cron run is something nobody sees.
 #
-# Secrets, both at *repo* level (the deploy ones live on the production
-# environment and are deliberately out of reach here):
-#   CLOUDFLARE_ANALYTICS_TOKEN  a token with ONLY Account Analytics: Read --
-#                               never the deploy token, which can write to
-#                               production
-#   CLOUDFLARE_ACCOUNT_ID       dashboard -> Workers & Pages -> Account ID
+# Secrets:
+#   CLOUDFLARE_ANALYTICS_TOKEN  a repo secret with ONLY Account Analytics:
+#                               Read -- never the deploy token, which can
+#                               write to production
+#   CLOUDFLARE_ACCOUNT_ID       the same repo secret deploy.yml uses
 name: Worker usage
 on:  # yamllint disable-line rule:truthy
   schedule:
@@ -48,8 +47,8 @@ jobs:
             value="${!var}"
             if [ -z "$value" ]; then
               echo "::error::Repository secret $secret is missing or empty." \
-                "It must be a repo-level secret (not only on the production" \
-                "environment); see the comment at the top of usage.yml."
+                "It must be visible outside the production environment; see" \
+                "the comment at the top of usage.yml."
               exit 1
             fi
             case "$value" in
@@ -71,24 +70,27 @@ jobs:
         shell: bash
         run: tools/cf-usage.py 8 --check 2>&1 | tee report.txt
 
-      - name: Open or update an issue so the failure is not just a grey X
+      # The report has to travel through a step output because the composite
+      # action below only takes literal inputs, not files from this job
+      - name: Collect the report for the issue body
+        id: report
         if: failure()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          title='Worker usage check failed'
-          report=$(cat report.txt 2>/dev/null || echo 'no report was produced; see the run log')
-          body="Weekly \`tools/cf-usage.py --check\` failed: $RUN_URL
+          {
+            echo 'body<<REPORT_EOF'
+            echo "Weekly \`tools/cf-usage.py --check\` failed: $RUN_URL"
+            echo
+            echo '```'
+            cat report.txt 2>/dev/null || echo 'no report was produced; see the run log'
+            echo '```'
+            echo 'REPORT_EOF'
+          } >> "$GITHUB_OUTPUT"
 
-          \`\`\`
-          $report
-          \`\`\`"
-          existing=$(gh issue list --state open --search "\"$title\" in:title" \
-            --json number --jq '.[0].number')
-          if [ -z "$existing" ]; then
-            gh issue create --title "$title" --body "$body"
-          else
-            gh issue comment "$existing" --body "$body"
-          fi
+      - name: Open or update an issue so the failure is not just a grey X
+        if: failure()
+        uses: ./.github/actions/report-issue
+        with:
+          title: Worker usage check failed
+          body: ${{ steps.report.outputs.body }}

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -1,0 +1,94 @@
+# Weekly report of the deployed Worker's usage against the free-tier limits,
+# because nobody runs tools/cf-usage.py by hand on a schedule. The check that
+# matters is CPU: the free plan allows 10 ms per invocation and the observed
+# p99 already sits near it (see CLAUDE.md). A failed check opens an issue --
+# a red X on a cron run is something nobody sees.
+#
+# Secrets, both at *repo* level (the deploy ones live on the production
+# environment and are deliberately out of reach here):
+#   CLOUDFLARE_ANALYTICS_TOKEN  a token with ONLY Account Analytics: Read --
+#                               never the deploy token, which can write to
+#                               production
+#   CLOUDFLARE_ACCOUNT_ID       dashboard -> Workers & Pages -> Account ID
+name: Worker usage
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '17 12 * * 1'  # Mondays, 12:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  usage:
+    name: Check Worker usage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository == 'scientific-python/circleci-artifacts-redirector-action'
+    permissions:
+      contents: read
+      issues: write
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_ANALYTICS_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+
+      # Same trap as deploy.yml: a missing or misnamed secret reads as empty
+      # with nothing saying so, and pasted whitespace survives into the
+      # Authorization header where it fails as an invalid header value.
+      - name: Check credentials
+        run: |
+          for pair in CLOUDFLARE_API_TOKEN=CLOUDFLARE_ANALYTICS_TOKEN \
+                      CLOUDFLARE_ACCOUNT_ID=CLOUDFLARE_ACCOUNT_ID; do
+            var="${pair%%=*}"
+            secret="${pair#*=}"
+            value="${!var}"
+            if [ -z "$value" ]; then
+              echo "::error::Repository secret $secret is missing or empty." \
+                "It must be a repo-level secret (not only on the production" \
+                "environment); see the comment at the top of usage.yml."
+              exit 1
+            fi
+            case "$value" in
+              *[[:space:]]*)
+                echo "::error::Repository secret $secret contains whitespace," \
+                  "most likely a trailing newline from pasting it in." \
+                  "Re-enter it with no leading or trailing whitespace."
+                exit 1
+                ;;
+            esac
+          done
+
+      # 8 days, not 7, so consecutive weekly runs overlap rather than leave a
+      # gap when cron fires late. --check exits non-zero on anything worth a
+      # look; "no requests at all" also exits non-zero, which is right -- a
+      # silent week more likely means deliveries stopped than that every repo
+      # went quiet.
+      - name: Report usage
+        shell: bash
+        run: tools/cf-usage.py 8 --check 2>&1 | tee report.txt
+
+      - name: Open or update an issue so the failure is not just a grey X
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title='Worker usage check failed'
+          report=$(cat report.txt 2>/dev/null || echo 'no report was produced; see the run log')
+          body="Weekly \`tools/cf-usage.py --check\` failed: $RUN_URL
+
+          \`\`\`
+          $report
+          \`\`\`"
+          existing=$(gh issue list --state open --search "\"$title\" in:title" \
+            --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh issue create --title "$title" --body "$body"
+          else
+            gh issue comment "$existing" --body "$body"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,13 +136,12 @@ CI never needs them and must never be given them.
 ### Deploying from CI
 
 `.github/workflows/deploy.yml` runs `wrangler deploy` on a published release or
-a manual `workflow_dispatch`. Two repo secrets, both scoped to the `production`
-environment:
+a manual `workflow_dispatch`. Two repo secrets:
 
 | Secret | What |
 |---|---|
 | `CLOUDFLARE_API_TOKEN` | dashboard → My Profile → API Tokens, **Edit Cloudflare Workers** template |
-| `CLOUDFLARE_ACCOUNT_ID` | dashboard → Workers & Pages → Account ID |
+| `CLOUDFLARE_ACCOUNT_ID` | dashboard → Workers & Pages → Account ID; an identifier rather than a credential, and also used by the weekly usage check |
 
 For local read-only work, mint a *second* token rather than reusing the deploy
 one — it can write to production. `tools/cf-usage.py` needs exactly **Account
@@ -242,10 +241,10 @@ else the token `wrangler login` stored). It reports CPU quantiles and invocation
 outcomes, and flags a p99 over the limit. `--check` exits non-zero on anything
 worth a look; `.github/workflows/usage.yml` runs that weekly and opens (or
 comments on) an issue on failure, so the limit check does not depend on anyone
-remembering to run it. That workflow needs two **repo-level** secrets:
-`CLOUDFLARE_ANALYTICS_TOKEN` (Account Analytics: Read **only**, never the
-deploy token) and `CLOUDFLARE_ACCOUNT_ID` (a second copy — the deploy one is
-scoped to the `production` environment, out of cron's reach by design).
+remembering to run it. It shares the `CLOUDFLARE_ACCOUNT_ID` repo secret with
+deploy but needs its own `CLOUDFLARE_ANALYTICS_TOKEN` — a repo secret with
+Account Analytics: Read **only**, never the deploy token, which can write to
+production.
 
 ## Where things stand (2026-07-28)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,16 @@ disable */` with a reason (see the entry-point guard in `index.js`).
 - **No semicolons, single quotes**, `eqeqeq` with `{null: 'ignore'}` — enforced
   by `eslint.config.mjs`, all autofixable with `npx eslint . --fix`.
 - **Rebuild `dist/`** in the same commit as any `index.js`/`src/` change, or
-  the action ships stale code. autofix.ci also does this on PRs.
+  the action ships stale code. autofix.ci also does this on PRs, and the
+  `check-dist` job in `tests.yaml` verifies it — on a `master` push a failure
+  opens an issue, because nobody watches post-merge CI.
+- **Bot PRs that touch `dist/` are never auto-merged.** `dist/` is what every
+  consumer of the action executes, so a dependency bump that autofix.ci
+  re-bundles must get human review — otherwise a compromised npm release would
+  flow to consumers' CI with no human in the loop. `automerge.yml` enforces it
+  (including *disabling* auto-merge when autofix pushes a rebuilt `dist/` to a
+  PR it already approved), and dependabot has a 14-day `cooldown` on npm so a
+  poisoned release is likely yanked before we ever see it.
 - **`.pre-commit-config.yaml` pins ESLint separately from `package.json`** and
   dependabot only updates the latter. Bump both together.
 - Style-only commits go in `.git-blame-ignore-revs`.
@@ -110,6 +119,12 @@ CI never needs them and must never be given them.
   an isolate-level `Map`. All best-effort: a cold isolate just refetches, and a
   duplicate can slip through. Nothing is correctness-critical.
 - Repos with no config file are inert, so a stale installation posts nothing.
+- **A failed delivery is lost — accepted.** GitHub never retries a webhook
+  delivery on its own, so when the Worker 500s on a transient CircleCI/GitHub
+  blip, that one status is never posted. A build emits several status events,
+  so the exposure is small; the "fix" (a cron job calling the App's redeliver
+  API) would hand App credentials to CI, which we deliberately never do. Manual
+  redelivery from Recent Deliveries covers the rare case that matters.
 - The config file is found by **listing `.github/` and matching
   `CONFIG_NAME`** (`circle(ci)?[-_]artifacts.ya?ml`) rather than fetching one
   fixed path: people migrate by `git mv`-ing their workflow, which is called
@@ -224,7 +239,13 @@ code that could walk the payload.
 
 Check real usage with `tools/cf-usage.py` (`$CLOUDFLARE_API_TOKEN` if exported,
 else the token `wrangler login` stored). It reports CPU quantiles and invocation
-outcomes, and flags a p99 over the limit.
+outcomes, and flags a p99 over the limit. `--check` exits non-zero on anything
+worth a look; `.github/workflows/usage.yml` runs that weekly and opens (or
+comments on) an issue on failure, so the limit check does not depend on anyone
+remembering to run it. That workflow needs two **repo-level** secrets:
+`CLOUDFLARE_ANALYTICS_TOKEN` (Account Analytics: Read **only**, never the
+deploy token) and `CLOUDFLARE_ACCOUNT_ID` (a second copy — the deploy one is
+scoped to the `production` environment, out of cron's reach by design).
 
 ## Where things stand (2026-07-28)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security policy
+
+This project ships two things that run in other people's infrastructure:
+
+- the **GitHub Action** (`dist/index.js`), which runs in consumers' CI with
+  their `GITHUB_TOKEN`, and
+- the **GitHub App** (`worker/index.js`), a Cloudflare Worker that posts
+  commit statuses to every repository the App is installed on.
+
+A vulnerability in either affects repositories beyond this one, so please
+report privately.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting: the **Security** tab of this
+repository, then **Report a vulnerability**. Please do not open a public
+issue or pull request for anything security-sensitive.
+
+## Supported versions
+
+The latest `v1` release of the action and the currently deployed Worker.
+Older releases do not receive fixes; consumers should track `v1` (or pin a
+full commit SHA and update it).

--- a/tools/cf-usage.py
+++ b/tools/cf-usage.py
@@ -7,7 +7,11 @@ cannot refresh it, so export the API token if you got tired of logging back in.
 A token needs only **Account Analytics: Read** if $CLOUDFLARE_ACCOUNT_ID is also
 exported, and additionally Account Settings: Read if it is not.
 
-Usage: ./cf-usage.py [days]  (default 7)
+Usage: ./cf-usage.py [days] [--check]  (default 7 days)
+
+--check exits non-zero when something needs attention -- CPU p99 over the
+free-tier limit, non-success invocation outcomes, or a peak day past half the
+request quota -- so CI can turn the report into an issue.
 """
 import json
 import os
@@ -88,7 +92,9 @@ query($tag:string!, $start:Time!, $end:Time!, $script:string!) {
 
 
 def main():
-    days = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+    args = [arg for arg in sys.argv[1:] if arg != '--check']
+    check = len(args) < len(sys.argv) - 1
+    days = int(args[0]) if args else 7
     tok = token()
 
     wrangler = Path(__file__).resolve().parent.parent / 'wrangler.toml'
@@ -140,12 +146,26 @@ def main():
     print('invocation outcomes: ' + (', '.join(f'{k}={v}' for k, v in bad.items())
                                      if bad else 'all success'))
 
+    problems = []
+    if bad:
+        problems.append(
+            'non-success invocation outcomes: '
+            + ', '.join(f'{k}={v}' for k, v in bad.items()))
+    if peak > DAILY_FREE_REQUESTS / 2:
+        problems.append(
+            f'peak day used {100 * peak / DAILY_FREE_REQUESTS:.0f}% of the '
+            f'{DAILY_FREE_REQUESTS:,} req/day quota')
     # Requests are not the binding constraint at this scale; CPU per invocation is.
     worst = max(row['quantiles']['cpuTimeP99'] for row in rows)
     if worst > FREE_CPU_LIMIT_US:
-        print(f'NOTE: peak cpu p99 {worst / 1000:.1f}ms exceeds the free '
-              f'{FREE_CPU_LIMIT_US / 1000:.0f}ms/invocation limit; Cloudflare tolerates '
-              f'infrequent overruns but kills consistent ones (error 1102)')
+        problems.append(
+            f'peak cpu p99 {worst / 1000:.1f}ms exceeds the free '
+            f'{FREE_CPU_LIMIT_US / 1000:.0f}ms/invocation limit; Cloudflare tolerates '
+            f'infrequent overruns but kills consistent ones (error 1102)')
+    for problem in problems:
+        print(f'NOTE: {problem}')
+    if check and problems:
+        sys.exit('--check: the NOTEs above need attention')
 
 
 main()

--- a/worker/index.js
+++ b/worker/index.js
@@ -220,7 +220,11 @@ export default {
       return await handle(request, env)
     } catch (error) {
       // A 500 tells GitHub the delivery failed, so it shows up in the App's
-      // "Recent Deliveries" tab rather than vanishing
+      // "Recent Deliveries" tab rather than vanishing. GitHub never retries a
+      // failed delivery on its own, so a transient CircleCI or GitHub blip
+      // means this one status is simply never posted -- accepted: a build
+      // emits several status events, and the fix (a cron redelivering via the
+      // App API) would put App credentials in CI. See CLAUDE.md.
       return new Response(String(error), {status: 500})
     }
   },


### PR DESCRIPTION
A batch of hardening/monitoring changes:

## Supply chain
- **Dependabot npm updates get a 14-day `cooldown`** before we see them — npm code is bundled into `dist/` and shipped to every consumer of the action, and most compromised releases are yanked within days.
- **Bot PRs that touch `dist/` are no longer auto-merged**: `automerge.yml` checks the diff, and also *disables* auto-merge it granted earlier if autofix.ci later pushes a rebuilt bundle to the PR (the workflow re-runs on `synchronize`). GHA pin bumps are unaffected — SHA-pinned, never bundled.

## dist/ freshness
New `check-dist` job in `tests.yaml` rebuilds `dist/` and diffs. autofix.ci already fixes PRs, but nothing guarded a direct push or an autofix outage, and a stale bundle on `master` ships silently to everyone on `@master` — so on a push, a failure opens an issue rather than just leaving a red X nobody sees.

## Weekly Worker usage check
`tools/cf-usage.py` gained `--check` (exit non-zero on CPU p99 over the free-tier 10 ms limit, non-success invocation outcomes, or a peak day past half the request quota). New `usage.yml` runs it Mondays over an 8-day window and opens an issue on failure. It reuses the existing `CLOUDFLARE_ACCOUNT_ID` repo secret plus a new `CLOUDFLARE_ANALYTICS_TOKEN` (Account Analytics: Read **only** — never the deploy token), already added.

Note: a live run today showed CPU p99 at 10.6–11.1 ms on 3 of the last 4 days (outcomes still all-success), so expect the first weekly run to open an issue — that is the check working.

The issue-opening (create, or comment on the open issue with the same title) is shared via a local composite action, `.github/actions/report-issue`.

## Docs & hygiene
- `SECURITY.md` pointing at GitHub private vulnerability reporting (needs enabling in repo settings)
- Documented the accepted lost-delivery failure mode (GitHub never retries a failed webhook delivery; the redeliver-API fix would put App credentials in CI) in CLAUDE.md and at the Worker's 500 handler
- `persist-credentials: false` on the autofix checkout, `timeout-minutes` on automerge
- Corrected CLAUDE.md: `CLOUDFLARE_ACCOUNT_ID` is a plain repo secret, not environment-scoped